### PR TITLE
fix(array): return maybeSingle for contract and metadata on hypercert

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -236,21 +236,16 @@ type GetHypercertsResponse {
   data: [Hypercert!]
 }
 
-type GetMetadataResponse {
-  count: Int
-  data: [Metadata!]
-}
-
 type Hypercert {
   attestations: GetAttestationsResponse
-  contracts: GetContractsResponse
+  contract: Contract
   contracts_id: ID
   creation_block_timestamp: BigInt
   fractions: GetFractionsResponse
   hypercert_id: ID
   id: ID!
   last_block_update_timestamp: BigInt
-  metadata: GetMetadataResponse
+  metadata: Metadata
   owner_address: String
   token_id: EthBigInt
   units: EthBigInt
@@ -274,7 +269,7 @@ input HypercertSortOptions {
 
 input HypercertsWhereInput {
   attestations: BasicAttestationWhereInput
-  contracts: BasicContractWhereInput
+  contract: BasicContractWhereInput
   creation_block_timestamp: NumberSearchOptions
   fractions: BasicFractionWhereInput
   hypercert_id: StringSearchOptions

--- a/src/client/graphql.ts
+++ b/src/client/graphql.ts
@@ -13,11 +13,11 @@ const defaultQuery = `{
     count
     data {
       hypercert_id
+      contract {
+          chain_id
+      }
       metadata {
-        data {
           name
-        }
-        count
       }
       attestations {
         count

--- a/src/graphql/schemas/args/hypercertsArgs.ts
+++ b/src/graphql/schemas/args/hypercertsArgs.ts
@@ -10,7 +10,7 @@ import {BasicFractionWhereInput} from "../inputs/fractionInput.js";
 @InputType()
 export class HypercertsWhereInput extends BasicHypercertWhereInput {
     @Field(_ => BasicContractWhereInput, {nullable: true})
-    contracts?: BasicContractWhereInput;
+    contract?: BasicContractWhereInput;
     @Field(_ => BasicMetadataWhereInput, {nullable: true})
     metadata?: BasicMetadataWhereInput;
     @Field(_ => BasicAttestationWhereInput, {nullable: true})

--- a/src/graphql/schemas/resolvers/hypercertResolver.ts
+++ b/src/graphql/schemas/resolvers/hypercertResolver.ts
@@ -53,21 +53,21 @@ class HypercertResolver {
         }
 
         try {
-            const res = await this.supabaseService.getMetadata({where: {uri: {eq: hypercert.uri}}});
+            const res = await this.supabaseService.getMetadata({where: {uri: {eq: hypercert.uri}}}).maybeSingle();
 
             if (!res) {
                 console.warn(`[HypercertResolver::metadata] Error fetching metadata for uri ${hypercert.uri}: `, res);
-                return {data: []};
+                return;
             }
 
-            const {data, error, count} = res;
+            const {data, error} = res;
 
             if (error) {
                 console.warn(`[HypercertResolver::metadata] Error fetching metadata for uri ${hypercert.uri}: `, error);
-                return {data};
+                return;
             }
 
-            return {data, count: count ? count : data?.length};
+            return data;
         } catch (e) {
             const error = e as Error;
             throw new Error(`[HypercertResolver::metadata] Error fetching metadata for uri ${hypercert.uri}: ${error.message}`)
@@ -75,27 +75,27 @@ class HypercertResolver {
     }
 
     @FieldResolver()
-    async contracts(@Root() hypercert: Partial<Hypercert>) {
+    async contract(@Root() hypercert: Partial<Hypercert>) {
         if (!hypercert.contracts_id) {
             return null;
         }
 
         try {
-            const res = await this.supabaseService.getContracts({where: {id: {eq: hypercert.contracts_id}}})
+            const res = await this.supabaseService.getContracts({where: {id: {eq: hypercert.contracts_id}}}).maybeSingle()
 
             if (!res) {
                 console.warn(`[HypercertResolver::contract] Error fetching contract with id ${hypercert.contracts_id}: `, res);
-                return {data: []};
+                return;
             }
 
             const {data, error, count} = res;
 
             if (error) {
                 console.warn(`[HypercertResolver::contract] Error fetching contract with id ${hypercert.contracts_id}: `, error);
-                return {data};
+                return;
             }
 
-            return {data, count: count ? count : data?.length}
+            return data;
         } catch (e) {
             const error = e as Error;
             throw new Error(`[HypercertResolver::contract] Error fetching contract with id ${hypercert.contracts_id}: ${error.message}`)

--- a/src/graphql/schemas/resolvers/metadataResolver.ts
+++ b/src/graphql/schemas/resolvers/metadataResolver.ts
@@ -5,7 +5,7 @@ import {SupabaseService} from "../../../services/SupabaseService.js";
 import {GetMetadataArgs} from "../args/metadataArgs.js";
 
 @ObjectType()
-export default class GetMetadataResponse {
+export class GetMetadataResponse {
     @Field(() => [Metadata], {nullable: true})
     data?: Metadata[];
 

--- a/src/graphql/schemas/typeDefs/hypercertTypeDefs.ts
+++ b/src/graphql/schemas/typeDefs/hypercertTypeDefs.ts
@@ -4,8 +4,8 @@ import GetAttestationsResponse from "../resolvers/attestationResolver.js";
 import {EthBigInt} from "../../scalars/ethBigInt.js";
 import {BasicTypeDef} from "./basicTypeDef.js";
 import GetFractionsResponse from "../resolvers/fractionResolver.js";
-import GetMetadataResponse from "../resolvers/metadataResolver.js";
-import GetContractsResponse from "../resolvers/contractResolver.js";
+import {Metadata} from "./metadataTypeDefs.js";
+import {Contract} from "./contractTypeDefs.js";
 
 
 @ObjectType()
@@ -31,14 +31,14 @@ class Hypercert extends BasicTypeDef {
     uri?: string;
 
     // Resolved fields
-    @Field(_ => GetAttestationsResponse, {nullable: true})
-    attestations?: GetAttestationsResponse;
-    @Field(_ => GetContractsResponse, {nullable: true})
-    contracts?: GetContractsResponse;
+    @Field(_ => Contract, {nullable: true})
+    contract?: Contract;
+    @Field(_ => Metadata, {nullable: true})
+    metadata?: Metadata;
     @Field(_ => GetFractionsResponse, {nullable: true})
     fractions?: GetFractionsResponse;
-    @Field(_ => GetMetadataResponse, {nullable: true})
-    metadata?: GetMetadataResponse;
+    @Field(_ => GetAttestationsResponse, {nullable: true})
+    attestations?: GetAttestationsResponse;
 }
 
 

--- a/src/services/SupabaseService.ts
+++ b/src/services/SupabaseService.ts
@@ -23,7 +23,7 @@ export class SupabaseService {
 
     // Contracts
 
-    async getContracts(args: GetContractsArgs) {
+    getContracts(args: GetContractsArgs) {
         let query = this.supabase.from('contracts').select('*');
 
         const {where, sort, offset, first} = args;
@@ -37,7 +37,7 @@ export class SupabaseService {
 
     // Claims
 
-    async getHypercerts(args: GetHypercertArgs) {
+    getHypercerts(args: GetHypercertArgs) {
 
         const fromString = `* ${args.where?.contracts ? ', contracts!inner (*)' : ''} ${args.where?.metadata ? ', metadata!inner (*)' : ''} ${args.where?.attestations ? ', attestations!inner (*)' : ''} ${args.where?.fractions ? ', fractions!inner (*)' : ''}`
 
@@ -59,7 +59,7 @@ export class SupabaseService {
 
     // Fractions
 
-    async getFractions(args: GetFractionArgs) {
+    getFractions(args: GetFractionArgs) {
         const fromString = `*`;
 
         let query = this.supabase.from('fractions').select(fromString, {
@@ -78,7 +78,7 @@ export class SupabaseService {
 
     // Metadata
 
-    async getMetadata(args: GetMetadataArgs) {
+    getMetadata(args: GetMetadataArgs) {
         let query = this.supabase.from('metadata').select('*');
         const {where, sort, offset, first} = args;
 
@@ -94,7 +94,7 @@ export class SupabaseService {
 
     // Attestations
 
-    async getAttestationSchemas(args: GetAttestationSchemaArgs) {
+    getAttestationSchemas(args: GetAttestationSchemaArgs) {
         let query = this.supabase.from('supported_schemas').select('*');
 
         const {where, sort, offset, first} = args;
@@ -106,7 +106,7 @@ export class SupabaseService {
         return query;
     }
 
-    async getAttestations(args: GetAttestationArgs) {
+    getAttestations(args: GetAttestationArgs) {
         const fromString = `* ${args.where?.hypercerts ? ', claims!inner (*)' : ''} ${args.where?.metadata ? ', metadata!inner (*)' : ''}`
 
         let query = this.supabase.from('attestations').select(fromString);

--- a/src/types/graphql-env.d.ts
+++ b/src/types/graphql-env.d.ts
@@ -1384,37 +1384,6 @@ export type introspection = {
       },
       {
         "kind": "OBJECT",
-        "name": "GetMetadataResponse",
-        "fields": [
-          {
-            "name": "count",
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "args": []
-          },
-          {
-            "name": "data",
-            "type": {
-              "kind": "LIST",
-              "ofType": {
-                "kind": "NON_NULL",
-                "ofType": {
-                  "kind": "OBJECT",
-                  "name": "Metadata",
-                  "ofType": null
-                }
-              }
-            },
-            "args": []
-          }
-        ],
-        "interfaces": []
-      },
-      {
-        "kind": "OBJECT",
         "name": "Hypercert",
         "fields": [
           {
@@ -1427,10 +1396,10 @@ export type introspection = {
             "args": []
           },
           {
-            "name": "contracts",
+            "name": "contract",
             "type": {
               "kind": "OBJECT",
-              "name": "GetContractsResponse",
+              "name": "Contract",
               "ofType": null
             },
             "args": []
@@ -1496,7 +1465,7 @@ export type introspection = {
             "name": "metadata",
             "type": {
               "kind": "OBJECT",
-              "name": "GetMetadataResponse",
+              "name": "Metadata",
               "ofType": null
             },
             "args": []
@@ -1637,7 +1606,7 @@ export type introspection = {
             }
           },
           {
-            "name": "contracts",
+            "name": "contract",
             "type": {
               "kind": "INPUT_OBJECT",
               "name": "BasicContractWhereInput",


### PR DESCRIPTION
Updated the hypercertsresolver to only return a single metadata and contracts object since there should only be one per hypercert