### PR TITLE
fix(upload): upload provided data after validation

### DIFF
--- a/src/controllers/AllowListController.ts
+++ b/src/controllers/AllowListController.ts
@@ -52,9 +52,7 @@ export class AllowListController extends Controller {
             };
         }
 
-        const _merkleTree = result.data as StandardMerkleTree<[string, bigint]>;
-
-        const cid = await storage.uploadFile({file: jsonToBlob(JSON.stringify(_merkleTree.dump()))});
+        const cid = await storage.uploadFile({file: jsonToBlob(requestBody.allowList)});
         this.setStatus(201)
 
         return {


### PR DESCRIPTION
Handler tried to make a dump of the allowlist entry array instead of uploading the data, resulting in 500s.

Fixed and uploaded an example list bafkreic3rmooknjyxw4knhyta4usodylcv4nb5l3gru7xqckrzaiw4mugu
