### PR TITLE
feat(records): add to graph with filter and sort

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -3,6 +3,53 @@
 # !!!   DO NOT MODIFY THIS FILE BY YOURSELF   !!!
 # -----------------------------------------------
 
+"""Records of allow list entries for claimable fractions"""
+type AllowlistRecord {
+  """Whether the fraction has been claimed"""
+  claimed: Boolean
+
+  """The entry index of the Merkle tree for the claimable fraction"""
+  entry: Float
+
+  """The hypercert ID the claimable fraction belongs to"""
+  hypercert_id: String
+  id: ID!
+
+  """The leaf of the Merkle tree for the claimable fraction"""
+  leaf: String
+
+  """The proof for the claimable fraction"""
+  proof: [String!]
+
+  """The token ID of the hypercert"""
+  token_id: String
+
+  """The total number of units held by the hypercert"""
+  total_units: BigInt
+
+  """The number of units of the claimable fraction"""
+  units: BigInt
+
+  """The address of the user who can claim the fraction"""
+  user_address: String
+}
+
+input AllowlistRecordFetchInput {
+  by: AllowlistRecordSortOptions
+}
+
+input AllowlistRecordSortOptions {
+  claimed: SortOrder
+  entry: SortOrder
+  hypercert_id: SortOrder
+  leaf: SortOrder
+  proof: SortOrder
+  token_id: SortOrder
+  total_units: SortOrder
+  units: SortOrder
+  user_address: SortOrder
+}
+
 type Attestation {
   attester: String
   block_timestamp: BigInt
@@ -75,6 +122,18 @@ input AttestationWhereInput {
   supported_schemas_id: StringSearchOptions
   token_id: StringSearchOptions
   uid: StringSearchOptions
+}
+
+input BasicAllowlistRecordWhereInput {
+  claimed: BooleanSearchOptions
+  entry: NumberSearchOptions
+  hypercert_id: StringSearchOptions
+  leaf: StringSearchOptions
+  proof: StringArraySearchOptions
+  token_id: NumberSearchOptions
+  total_units: NumberSearchOptions
+  units: NumberSearchOptions
+  user_address: StringSearchOptions
 }
 
 input BasicAttestationSchemaWhereInput {
@@ -258,6 +317,11 @@ input FractionWhereInput {
   owner_address: StringSearchOptions
   token_id: NumberSearchOptions
   units: NumberSearchOptions
+}
+
+type GetAllowlistRecordResponse {
+  count: Int
+  data: [AllowlistRecord!]
 }
 
 type GetAttestationsResponse {
@@ -466,6 +530,7 @@ input OrderFetchInput {
 }
 
 type Query {
+  allowlistRecords(count: CountKeys, first: Int, offset: Int, sort: AllowlistRecordFetchInput, where: BasicAllowlistRecordWhereInput): GetAllowlistRecordResponse!
   attestationSchemas(count: CountKeys, first: Int, offset: Int, sort: AttestationSchemaFetchInput, where: AttestationSchemaWhereInput): GetAttestationsSchemaResponse!
   attestations(count: CountKeys, first: Int, offset: Int, sort: AttestationFetchInput, where: AttestationWhereInput): GetAttestationsResponse!
   collections(count: CountKeys, first: Int, offset: Int, sort: CollectionFetchInput, where: BasicCollectionWhereInput): GetCollectionsResponse!

--- a/src/graphql/schemas/args/allowlistRecordArgs.ts
+++ b/src/graphql/schemas/args/allowlistRecordArgs.ts
@@ -1,0 +1,11 @@
+import { ArgsType, Field } from "type-graphql";
+import { PaginationArgs } from "./paginationArgs.js";
+import {AllowlistRecordFetchInput, BasicAllowlistRecordWhereInput} from "../inputs/allowlistRecordsInput.js";
+
+@ArgsType()
+export class GetAllowlistRecordsArgs extends PaginationArgs {
+  @Field({ nullable: true })
+  where?: BasicAllowlistRecordWhereInput;
+  @Field({ nullable: true })
+  sort?: AllowlistRecordFetchInput;
+}

--- a/src/graphql/schemas/inputs/allowlistRecordsInput.ts
+++ b/src/graphql/schemas/inputs/allowlistRecordsInput.ts
@@ -1,0 +1,40 @@
+import {Field, InputType} from "type-graphql";
+import type {WhereOptions} from "./whereOptions.js";
+import {
+    BooleanSearchOptions,
+    IdSearchOptions,
+    NumberSearchOptions,
+    StringArraySearchOptions,
+    StringSearchOptions
+} from "./searchOptions.js";
+import type {OrderOptions} from "./orderOptions.js";
+import {AllowlistRecordSortOptions} from "./sortOptions.js";
+import {AllowlistRecord} from "../typeDefs/allowlistRecordTypeDefs.js";
+
+@InputType()
+export class BasicAllowlistRecordWhereInput implements WhereOptions<AllowlistRecord> {
+    @Field(() => StringSearchOptions, {nullable: true})
+    hypercert_id?: StringSearchOptions;
+    @Field(() => NumberSearchOptions, {nullable: true})
+    token_id?: NumberSearchOptions;
+    @Field(() => StringSearchOptions, {nullable: true})
+    leaf?: StringSearchOptions;
+    @Field(() => NumberSearchOptions, {nullable: true})
+    entry?: NumberSearchOptions;
+    @Field(() => StringSearchOptions, {nullable: true})
+    user_address?: StringSearchOptions;
+    @Field(() => BooleanSearchOptions, {nullable: true})
+    claimed?: BooleanSearchOptions;
+    @Field(() => StringArraySearchOptions, {nullable: true})
+    proof?: StringArraySearchOptions;
+    @Field(() => NumberSearchOptions, {nullable: true})
+    units?: NumberSearchOptions;
+    @Field(() => NumberSearchOptions, {nullable: true})
+    total_units?: NumberSearchOptions;
+}
+
+@InputType()
+export class AllowlistRecordFetchInput implements OrderOptions<AllowlistRecord> {
+    @Field((_) => AllowlistRecordSortOptions, {nullable: true})
+    by?: AllowlistRecordSortOptions;
+}

--- a/src/graphql/schemas/inputs/orderOptions.ts
+++ b/src/graphql/schemas/inputs/orderOptions.ts
@@ -3,11 +3,12 @@ import {
     AttestationSortOptions,
     ContractSortOptions, FractionSortOptions,
     HypercertSortOptions,
-    MetadataSortOptions
+    MetadataSortOptions,
+    AllowlistRecordSortOptions
 } from "./sortOptions.js";
 
 
 export type OrderOptions<T extends object> = {
-    by?: HypercertSortOptions | ContractSortOptions | MetadataSortOptions | AttestationSortOptions | AttestationSchemaSortOptions | FractionSortOptions | null;
+    by?: HypercertSortOptions | ContractSortOptions | MetadataSortOptions | AttestationSortOptions | AttestationSchemaSortOptions | FractionSortOptions | AllowlistRecordSortOptions | null;
 }
 

--- a/src/graphql/schemas/inputs/sortOptions.ts
+++ b/src/graphql/schemas/inputs/sortOptions.ts
@@ -96,3 +96,25 @@ export class FractionSortOptions implements SortOptions<Fraction> {
     @Field(_ => SortOrder, {nullable: true})
     owner_address?: SortOrder;
 }
+
+@InputType()
+export class AllowlistRecordSortOptions implements SortOptions<Hypercert> {
+    @Field(_ => SortOrder, {nullable: true})
+    hypercert_id?: SortOrder;
+    @Field(_ => SortOrder, {nullable: true})
+    token_id?: SortOrder;
+    @Field(_ => SortOrder, {nullable: true})
+    leaf?: SortOrder;
+    @Field(_ => SortOrder, {nullable: true})
+    entry?: SortOrder;
+    @Field(_ => SortOrder, {nullable: true})
+    user_address?: SortOrder;
+    @Field(_ => SortOrder, {nullable: true})
+    claimed?: SortOrder;
+    @Field(_ => SortOrder, {nullable: true})
+    proof?: SortOrder;
+    @Field(_ => SortOrder, {nullable: true})
+    units?: SortOrder;
+    @Field(_ => SortOrder, {nullable: true})
+    total_units?: SortOrder;
+}

--- a/src/graphql/schemas/resolvers/allowlistRecordResolver.ts
+++ b/src/graphql/schemas/resolvers/allowlistRecordResolver.ts
@@ -1,0 +1,50 @@
+import {Args, Field, Int, ObjectType, Query, Resolver} from "type-graphql";
+import {inject, injectable} from "tsyringe";
+import {SupabaseCachingService} from "../../../services/SupabaseCachingService.js";
+import {AllowlistRecord} from "../typeDefs/allowlistRecordTypeDefs.js";
+import {GetAllowlistRecordsArgs} from "../args/allowlistRecordArgs.js";
+
+@ObjectType()
+export default class GetAllowlistRecordResponse {
+    @Field(() => [AllowlistRecord], {nullable: true})
+    data?: AllowlistRecord[];
+
+    @Field(() => Int, {nullable: true})
+    count?: number;
+}
+
+@injectable()
+@Resolver((_) => AllowlistRecord)
+class AllowlistRecordResolver {
+    constructor(
+        @inject(SupabaseCachingService)
+        private readonly supabaseCachingService: SupabaseCachingService,
+    ) {
+    }
+
+    @Query((_) => GetAllowlistRecordResponse)
+    async allowlistRecords(@Args() args: GetAllowlistRecordsArgs) {
+        try {
+            const res = await this.supabaseCachingService.getAllowlistRecords(args);
+
+            const {data, error, count} = res;
+
+            if (error) {
+                console.warn(
+                    `[AllowlistRecordResolver::allowlistRecords] Error fetching orders: `,
+                    error,
+                );
+                return {data};
+            }
+
+            return {data, count: count ? count : data?.length};
+        } catch (e) {
+            throw new Error(
+                `[AllowlistRecordResolver::allowlistRecords] Error fetching orders: ${(e as Error).message}`,
+            );
+        }
+    }
+
+}
+
+export {AllowlistRecordResolver};

--- a/src/graphql/schemas/resolvers/composed.ts
+++ b/src/graphql/schemas/resolvers/composed.ts
@@ -1,19 +1,21 @@
-import { HypercertResolver } from "./hypercertResolver.js";
-import { MetadataResolver } from "./metadataResolver.js";
-import { ContractResolver } from "./contractResolver.js";
-import { FractionResolver } from "./fractionResolver.js";
-import { AttestationResolver } from "./attestationResolver.js";
-import { AttestationSchemaResolver } from "./attestationSchemaResolver.js";
-import { OrderResolver } from "./orderResolver.js";
-import { CollectionResolver } from "./collectionResolver.js";
+import {HypercertResolver} from "./hypercertResolver.js";
+import {MetadataResolver} from "./metadataResolver.js";
+import {ContractResolver} from "./contractResolver.js";
+import {FractionResolver} from "./fractionResolver.js";
+import {AttestationResolver} from "./attestationResolver.js";
+import {AttestationSchemaResolver} from "./attestationSchemaResolver.js";
+import {OrderResolver} from "./orderResolver.js";
+import {CollectionResolver} from "./collectionResolver.js";
+import {AllowlistRecordResolver} from "./allowlistRecordResolver.js";
 
 export const resolvers = [
-  ContractResolver,
-  FractionResolver,
-  MetadataResolver,
-  HypercertResolver,
-  AttestationResolver,
-  AttestationSchemaResolver,
-  OrderResolver,
-  CollectionResolver
+    ContractResolver,
+    FractionResolver,
+    MetadataResolver,
+    HypercertResolver,
+    AttestationResolver,
+    AttestationSchemaResolver,
+    OrderResolver,
+    CollectionResolver,
+    AllowlistRecordResolver
 ] as const;

--- a/src/graphql/schemas/typeDefs/allowlistRecordTypeDefs.ts
+++ b/src/graphql/schemas/typeDefs/allowlistRecordTypeDefs.ts
@@ -1,0 +1,27 @@
+import {Field, ObjectType} from "type-graphql";
+import {GraphQLBigInt} from "graphql-scalars";
+import {BasicTypeDef} from "./basicTypeDef.js";
+
+@ObjectType({description: "Records of allow list entries for claimable fractions"})
+class AllowlistRecord extends BasicTypeDef {
+    @Field({nullable: true, description: "The hypercert ID the claimable fraction belongs to"})
+    hypercert_id?: string;
+    @Field({nullable: true, description: "The token ID of the hypercert"})
+    token_id?: string;
+    @Field({nullable: true, description: "The leaf of the Merkle tree for the claimable fraction"})
+    leaf?: string;
+    @Field({nullable: true, description: "The entry index of the Merkle tree for the claimable fraction"})
+    entry?: number;
+    @Field({nullable: true, description: "The address of the user who can claim the fraction"})
+    user_address?: string;
+    @Field({nullable: true, description: "Whether the fraction has been claimed"})
+    claimed?: boolean;
+    @Field(() => [String], {nullable: true, description: "The proof for the claimable fraction"})
+    proof?: string[];
+    @Field(() => GraphQLBigInt, {nullable: true, description: "The number of units of the claimable fraction"})
+    units?: bigint | number;
+    @Field(() => GraphQLBigInt, {nullable: true, description: "The total number of units held by the hypercert"})
+    total_units?: bigint | number;
+}
+
+export {AllowlistRecord};

--- a/src/graphql/schemas/typeDefs/orderTypeDefs.ts
+++ b/src/graphql/schemas/typeDefs/orderTypeDefs.ts
@@ -1,8 +1,6 @@
 import { Field, ObjectType } from "type-graphql";
 import { GraphQLBigInt } from "graphql-scalars";
 import { BasicTypeDef } from "./basicTypeDef.js";
-import GetFractionsResponse from "../resolvers/fractionResolver.js";
-import { Fraction } from "./fractionTypeDefs.js";
 
 @ObjectType()
 class Order extends BasicTypeDef {

--- a/src/services/SupabaseCachingService.ts
+++ b/src/services/SupabaseCachingService.ts
@@ -93,6 +93,18 @@ export class SupabaseCachingService {
 
     // Allow lists
 
+    getAllowlistRecords(args: Get) {
+        let query = this.supabaseCaching.from("claimable_fractions_with_proofs").select("*");
+
+        const {where, sort, offset, first} = args;
+
+        query = applyFilters({query, where});
+        query = applySorting({query, sort});
+        query = applyPagination({query, pagination: {first, offset}});
+
+        return query;
+    }
+
     // Attestations
 
     getAttestationSchemas(args: GetAttestationSchemaArgs) {

--- a/src/types/graphql-env.d.ts
+++ b/src/types/graphql-env.d.ts
@@ -19,6 +19,220 @@ export type introspection = {
     "types": [
       {
         "kind": "OBJECT",
+        "name": "AllowlistRecord",
+        "fields": [
+          {
+            "name": "claimed",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Boolean",
+              "ofType": null
+            },
+            "args": []
+          },
+          {
+            "name": "entry",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "args": []
+          },
+          {
+            "name": "hypercert_id",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "args": []
+          },
+          {
+            "name": "id",
+            "type": {
+              "kind": "NON_NULL",
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              }
+            },
+            "args": []
+          },
+          {
+            "name": "leaf",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "args": []
+          },
+          {
+            "name": "proof",
+            "type": {
+              "kind": "LIST",
+              "ofType": {
+                "kind": "NON_NULL",
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            "args": []
+          },
+          {
+            "name": "token_id",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "args": []
+          },
+          {
+            "name": "total_units",
+            "type": {
+              "kind": "SCALAR",
+              "name": "BigInt",
+              "ofType": null
+            },
+            "args": []
+          },
+          {
+            "name": "units",
+            "type": {
+              "kind": "SCALAR",
+              "name": "BigInt",
+              "ofType": null
+            },
+            "args": []
+          },
+          {
+            "name": "user_address",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "args": []
+          }
+        ],
+        "interfaces": []
+      },
+      {
+        "kind": "SCALAR",
+        "name": "Boolean"
+      },
+      {
+        "kind": "SCALAR",
+        "name": "Float"
+      },
+      {
+        "kind": "SCALAR",
+        "name": "String"
+      },
+      {
+        "kind": "SCALAR",
+        "name": "ID"
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "AllowlistRecordFetchInput",
+        "inputFields": [
+          {
+            "name": "by",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "AllowlistRecordSortOptions",
+              "ofType": null
+            }
+          }
+        ]
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "AllowlistRecordSortOptions",
+        "inputFields": [
+          {
+            "name": "claimed",
+            "type": {
+              "kind": "ENUM",
+              "name": "SortOrder",
+              "ofType": null
+            }
+          },
+          {
+            "name": "entry",
+            "type": {
+              "kind": "ENUM",
+              "name": "SortOrder",
+              "ofType": null
+            }
+          },
+          {
+            "name": "hypercert_id",
+            "type": {
+              "kind": "ENUM",
+              "name": "SortOrder",
+              "ofType": null
+            }
+          },
+          {
+            "name": "leaf",
+            "type": {
+              "kind": "ENUM",
+              "name": "SortOrder",
+              "ofType": null
+            }
+          },
+          {
+            "name": "proof",
+            "type": {
+              "kind": "ENUM",
+              "name": "SortOrder",
+              "ofType": null
+            }
+          },
+          {
+            "name": "token_id",
+            "type": {
+              "kind": "ENUM",
+              "name": "SortOrder",
+              "ofType": null
+            }
+          },
+          {
+            "name": "total_units",
+            "type": {
+              "kind": "ENUM",
+              "name": "SortOrder",
+              "ofType": null
+            }
+          },
+          {
+            "name": "units",
+            "type": {
+              "kind": "ENUM",
+              "name": "SortOrder",
+              "ofType": null
+            }
+          },
+          {
+            "name": "user_address",
+            "type": {
+              "kind": "ENUM",
+              "name": "SortOrder",
+              "ofType": null
+            }
+          }
+        ]
+      },
+      {
+        "kind": "OBJECT",
         "name": "Attestation",
         "fields": [
           {
@@ -124,14 +338,6 @@ export type introspection = {
         "interfaces": []
       },
       {
-        "kind": "SCALAR",
-        "name": "String"
-      },
-      {
-        "kind": "SCALAR",
-        "name": "ID"
-      },
-      {
         "kind": "INPUT_OBJECT",
         "name": "AttestationFetchInput",
         "inputFields": [
@@ -223,10 +429,6 @@ export type introspection = {
           }
         ],
         "interfaces": []
-      },
-      {
-        "kind": "SCALAR",
-        "name": "Boolean"
       },
       {
         "kind": "INPUT_OBJECT",
@@ -506,6 +708,84 @@ export type introspection = {
           },
           {
             "name": "uid",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "StringSearchOptions",
+              "ofType": null
+            }
+          }
+        ]
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "BasicAllowlistRecordWhereInput",
+        "inputFields": [
+          {
+            "name": "claimed",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "BooleanSearchOptions",
+              "ofType": null
+            }
+          },
+          {
+            "name": "entry",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "NumberSearchOptions",
+              "ofType": null
+            }
+          },
+          {
+            "name": "hypercert_id",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "StringSearchOptions",
+              "ofType": null
+            }
+          },
+          {
+            "name": "leaf",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "StringSearchOptions",
+              "ofType": null
+            }
+          },
+          {
+            "name": "proof",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "StringArraySearchOptions",
+              "ofType": null
+            }
+          },
+          {
+            "name": "token_id",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "NumberSearchOptions",
+              "ofType": null
+            }
+          },
+          {
+            "name": "total_units",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "NumberSearchOptions",
+              "ofType": null
+            }
+          },
+          {
+            "name": "units",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "NumberSearchOptions",
+              "ofType": null
+            }
+          },
+          {
+            "name": "user_address",
             "type": {
               "kind": "INPUT_OBJECT",
               "name": "StringSearchOptions",
@@ -1426,6 +1706,41 @@ export type introspection = {
       },
       {
         "kind": "OBJECT",
+        "name": "GetAllowlistRecordResponse",
+        "fields": [
+          {
+            "name": "count",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "args": []
+          },
+          {
+            "name": "data",
+            "type": {
+              "kind": "LIST",
+              "ofType": {
+                "kind": "NON_NULL",
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "AllowlistRecord",
+                  "ofType": null
+                }
+              }
+            },
+            "args": []
+          }
+        ],
+        "interfaces": []
+      },
+      {
+        "kind": "SCALAR",
+        "name": "Int"
+      },
+      {
+        "kind": "OBJECT",
         "name": "GetAttestationsResponse",
         "fields": [
           {
@@ -1454,10 +1769,6 @@ export type introspection = {
           }
         ],
         "interfaces": []
-      },
-      {
-        "kind": "SCALAR",
-        "name": "Int"
       },
       {
         "kind": "OBJECT",
@@ -2687,10 +2998,6 @@ export type introspection = {
         "interfaces": []
       },
       {
-        "kind": "SCALAR",
-        "name": "Float"
-      },
-      {
         "kind": "INPUT_OBJECT",
         "name": "OrderFetchInput",
         "inputFields": [
@@ -2708,6 +3015,59 @@ export type introspection = {
         "kind": "OBJECT",
         "name": "Query",
         "fields": [
+          {
+            "name": "allowlistRecords",
+            "type": {
+              "kind": "NON_NULL",
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "GetAllowlistRecordResponse",
+                "ofType": null
+              }
+            },
+            "args": [
+              {
+                "name": "count",
+                "type": {
+                  "kind": "ENUM",
+                  "name": "CountKeys",
+                  "ofType": null
+                }
+              },
+              {
+                "name": "first",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              {
+                "name": "offset",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              {
+                "name": "sort",
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "AllowlistRecordFetchInput",
+                  "ofType": null
+                }
+              },
+              {
+                "name": "where",
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "BasicAllowlistRecordWhereInput",
+                  "ofType": null
+                }
+              }
+            ]
+          },
           {
             "name": "attestationSchemas",
             "type": {

--- a/src/types/supabaseCaching.ts
+++ b/src/types/supabaseCaching.ts
@@ -497,6 +497,22 @@ export type Database = {
       }
     }
     Views: {
+      claimable_fractions_with_proofs: {
+        Row: {
+          claimed: boolean | null
+          entry: number | null
+          hypercert_id: string | null
+          id: string | null
+          leaf: string | null
+          proof: Json | null
+          root: string | null
+          token_id: number | null
+          total_units: number | null
+          units: number | null
+          user_address: string | null
+        }
+        Relationships: []
+      }
       hypercert_allow_list_records_with_token_id: {
         Row: {
           claimed: boolean | null


### PR DESCRIPTION
Adds claimable allow list records to graph

```graphql
{
  allowlistRecords(
    count: COUNT
    where: {user_address: {contains: "0x3506e5f79754e8aad83152b8e6189b6c5508aad4"}, claimed: {eq: false}}
  ) {
    count
    data {
      claimed
      entry
      user_address
    }
  }
}
```