### PR TITLE
fix(gql): add missing sales fields to typedefs

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -239,8 +239,16 @@ input BasicOrderWhereInput {
 }
 
 input BasicSaleWhereInput {
+  amounts: NumberArraySearchOptions
+  buyer: StringSearchOptions
+  collection: StringSearchOptions
+  creation_block_number: NumberSearchOptions
+  creation_block_timestamp: NumberSearchOptions
+  currency: StringSearchOptions
   hypercert_id: StringSearchOptions
   item_ids: StringArraySearchOptions
+  seller: StringSearchOptions
+  strategy_id: NumberSearchOptions
   transaction_hash: IdSearchOptions
 }
 
@@ -583,6 +591,10 @@ input MetadataWhereInput {
   work_scope: StringArraySearchOptions
   work_timeframe_from: NumberSearchOptions
   work_timeframe_to: NumberSearchOptions
+}
+
+input NumberArraySearchOptions {
+  contains: [BigInt!]
 }
 
 input NumberSearchOptions {

--- a/src/graphql/schemas/inputs/salesInput.ts
+++ b/src/graphql/schemas/inputs/salesInput.ts
@@ -1,9 +1,9 @@
 import { Field, InputType } from "type-graphql";
 import type { WhereOptions } from "./whereOptions.js";
 import {
-  IdSearchOptions,
+  IdSearchOptions, NumberArraySearchOptions, NumberSearchOptions,
   StringArraySearchOptions,
-  StringSearchOptions,
+  StringSearchOptions
 } from "./searchOptions.js";
 import { ContractSortOptions } from "./sortOptions.js";
 import { Sale } from "../typeDefs/salesTypeDefs.js";
@@ -19,6 +19,30 @@ export class BasicSaleWhereInput implements WhereOptions<Sale> {
 
   @Field(() => StringArraySearchOptions, { nullable: true })
   item_ids?: StringArraySearchOptions | null;
+
+  @Field(() => StringSearchOptions, { nullable: true })
+  currency?: StringSearchOptions | null;
+
+  @Field(() => StringSearchOptions, { nullable: true })
+  collection?: StringSearchOptions | null;
+
+  @Field(() => StringSearchOptions, { nullable: true })
+  buyer?: StringSearchOptions | null;
+
+  @Field(() => StringSearchOptions, { nullable: true })
+  seller?: StringSearchOptions | null;
+
+  @Field(() => NumberSearchOptions, { nullable: true })
+  strategy_id?: NumberSearchOptions | null;
+
+  @Field(() => NumberSearchOptions, { nullable: true })
+  creation_block_number?: NumberSearchOptions | null;
+
+  @Field(() => NumberSearchOptions, { nullable: true })
+  creation_block_timestamp?: NumberSearchOptions | null;
+
+  @Field(() => NumberArraySearchOptions, { nullable: true })
+  amounts?: NumberArraySearchOptions | null;
 }
 
 @InputType()

--- a/src/graphql/schemas/inputs/searchOptions.ts
+++ b/src/graphql/schemas/inputs/searchOptions.ts
@@ -1,4 +1,4 @@
-import { Field, ID, InputType } from "type-graphql";
+import { Field, InputType } from "type-graphql";
 import { GraphQLBigInt, GraphQLUUID } from "graphql-scalars";
 
 @InputType()
@@ -9,7 +9,7 @@ export class BooleanSearchOptions {
 
 @InputType()
 export class IdSearchOptions {
-  @Field((_) => GraphQLUUID, { nullable: true })
+  @Field(() => GraphQLUUID, { nullable: true })
   eq?: string;
 }
 
@@ -30,19 +30,19 @@ export class StringSearchOptions {
 
 @InputType()
 export class NumberSearchOptions {
-  @Field((_) => GraphQLBigInt, { nullable: true })
+  @Field(() => GraphQLBigInt, { nullable: true })
   eq?: bigint | number;
 
-  @Field((_) => GraphQLBigInt, { nullable: true })
+  @Field(() => GraphQLBigInt, { nullable: true })
   gt?: bigint | number;
 
-  @Field((_) => GraphQLBigInt, { nullable: true })
+  @Field(() => GraphQLBigInt, { nullable: true })
   gte?: bigint | number;
 
-  @Field((_) => GraphQLBigInt, { nullable: true })
+  @Field(() => GraphQLBigInt, { nullable: true })
   lt?: bigint | number;
 
-  @Field((_) => GraphQLBigInt, { nullable: true })
+  @Field(() => GraphQLBigInt, { nullable: true })
   lte?: bigint | number;
 }
 
@@ -54,6 +54,6 @@ export class StringArraySearchOptions {
 
 @InputType()
 export class NumberArraySearchOptions {
-  @Field((_) => [GraphQLBigInt], { nullable: true })
+  @Field(() => [GraphQLBigInt], { nullable: true })
   contains?: bigint[] | number[];
 }

--- a/src/types/graphql-env.d.ts
+++ b/src/types/graphql-env.d.ts
@@ -1459,6 +1459,54 @@ export type introspection = {
         "name": "BasicSaleWhereInput",
         "inputFields": [
           {
+            "name": "amounts",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "NumberArraySearchOptions",
+              "ofType": null
+            }
+          },
+          {
+            "name": "buyer",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "StringSearchOptions",
+              "ofType": null
+            }
+          },
+          {
+            "name": "collection",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "StringSearchOptions",
+              "ofType": null
+            }
+          },
+          {
+            "name": "creation_block_number",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "NumberSearchOptions",
+              "ofType": null
+            }
+          },
+          {
+            "name": "creation_block_timestamp",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "NumberSearchOptions",
+              "ofType": null
+            }
+          },
+          {
+            "name": "currency",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "StringSearchOptions",
+              "ofType": null
+            }
+          },
+          {
             "name": "hypercert_id",
             "type": {
               "kind": "INPUT_OBJECT",
@@ -1471,6 +1519,22 @@ export type introspection = {
             "type": {
               "kind": "INPUT_OBJECT",
               "name": "StringArraySearchOptions",
+              "ofType": null
+            }
+          },
+          {
+            "name": "seller",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "StringSearchOptions",
+              "ofType": null
+            }
+          },
+          {
+            "name": "strategy_id",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "NumberSearchOptions",
               "ofType": null
             }
           },
@@ -3209,6 +3273,26 @@ export type introspection = {
               "kind": "INPUT_OBJECT",
               "name": "NumberSearchOptions",
               "ofType": null
+            }
+          }
+        ]
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "NumberArraySearchOptions",
+        "inputFields": [
+          {
+            "name": "contains",
+            "type": {
+              "kind": "LIST",
+              "ofType": {
+                "kind": "NON_NULL",
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "BigInt",
+                  "ofType": null
+                }
+              }
             }
           }
         ]


### PR DESCRIPTION
Add fields to Sales typedef for querying sales: buyer, seller, etc..