### PR TITLE
fix(migration): drop policy if already exists

### DIFF
--- a/supabase/migrations/20240813175015_add_rls_policy_for_orders.sql
+++ b/supabase/migrations/20240813175015_add_rls_policy_for_orders.sql
@@ -1,3 +1,5 @@
+drop policy if exists "Enable read access for all users" on "public"."marketplace_orders";
+
 alter table "public"."marketplace_orders"
     enable row level security;
 


### PR DESCRIPTION
Updates latest migration to drop policy if it already exists
