### PR TITLE
Restore count

### DIFF
--- a/src/graphql/schemas/args/baseArgs.ts
+++ b/src/graphql/schemas/args/baseArgs.ts
@@ -1,15 +1,18 @@
 import { Field, ArgsType, ClassType, Int } from "type-graphql";
 import { WhereOptions } from "../inputs/whereOptions.js";
-import { SortOptions } from "../inputs/sortOptions.js";
+import { OrderOptions } from "../inputs/orderOptions.js";
 
 export type BaseArgs<T extends object> = {
   where?: WhereOptions<T>;
-  sort?: SortOptions<T>;
+  sort?: OrderOptions<T>;
 };
 
 export function withPagination<TItem extends ClassType>(TItemClass: TItem) {
   @ArgsType()
   class withPaginationClass extends TItemClass {
+    @Field(() => Int, { nullable: true })
+    first?: number;
+
     @Field(() => Int, { nullable: true })
     first?: number;
 

--- a/src/graphql/schemas/resolvers/baseTypes.ts
+++ b/src/graphql/schemas/resolvers/baseTypes.ts
@@ -40,13 +40,21 @@ export function createBaseResolver<T extends ClassType>(
       );
 
       try {
+        const queries = this.supabaseCachingService.getMetadata(args);
         if (single) {
-          return this.supabaseCachingService
-            .getMetadata(args)
-            .executeTakeFirst();
+          return queries.data.executeTakeFirst();
         }
 
-        return this.supabaseCachingService.getMetadata(args).execute();
+        return this.supabaseCachingService.db
+          .transaction()
+          .execute(async (transaction) => {
+            const dataRes = await transaction.executeQuery(queries.data);
+            const countRes = await transaction.executeQuery(queries.count);
+            return {
+              data: dataRes.rows,
+              count: countRes.rows[0].count,
+            };
+          });
       } catch (e) {
         const error = e as Error;
         throw new Error(
@@ -61,13 +69,21 @@ export function createBaseResolver<T extends ClassType>(
       );
 
       try {
+        const queries = this.supabaseCachingService.getContracts(args);
         if (single) {
-          return this.supabaseCachingService
-            .getContracts(args)
-            .executeTakeFirst();
+          return queries.data.executeTakeFirst();
         }
 
-        return this.supabaseCachingService.getContracts(args).execute();
+        return this.supabaseCachingService.db
+          .transaction()
+          .execute(async (transaction) => {
+            const dataRes = await transaction.executeQuery(queries.data);
+            const countRes = await transaction.executeQuery(queries.count);
+            return {
+              data: dataRes.rows,
+              count: countRes.rows[0].count,
+            };
+          });
       } catch (e) {
         const error = e as Error;
         throw new Error(
@@ -82,13 +98,21 @@ export function createBaseResolver<T extends ClassType>(
       );
 
       try {
+        const queries = this.supabaseCachingService.getHypercerts(args);
         if (single) {
-          return this.supabaseCachingService
-            .getHypercerts(args)
-            .executeTakeFirst();
+          return queries.data.executeTakeFirst();
         }
 
-        return this.supabaseCachingService.getHypercerts(args).execute();
+        return this.supabaseCachingService.db
+          .transaction()
+          .execute(async (transaction) => {
+            const dataRes = await transaction.executeQuery(queries.data);
+            const countRes = await transaction.executeQuery(queries.count);
+            return {
+              data: dataRes.rows,
+              count: countRes.rows[0].count,
+            };
+          });
       } catch (e) {
         const error = e as Error;
         throw new Error(
@@ -103,13 +127,21 @@ export function createBaseResolver<T extends ClassType>(
       );
 
       try {
+        const queries = this.supabaseCachingService.getFractions(args);
         if (single) {
-          return this.supabaseCachingService
-            .getFractions(args)
-            .executeTakeFirst();
+          return queries.data.executeTakeFirst();
         }
 
-        return this.supabaseCachingService.getFractions(args).execute();
+        return this.supabaseCachingService.db
+          .transaction()
+          .execute(async (transaction) => {
+            const dataRes = await transaction.executeQuery(queries.data);
+            const countRes = await transaction.executeQuery(queries.count);
+            return {
+              data: dataRes.rows,
+              count: countRes.rows[0].count,
+            };
+          });
       } catch (e) {
         const error = e as Error;
         throw new Error(
@@ -127,13 +159,21 @@ export function createBaseResolver<T extends ClassType>(
       );
 
       try {
+        const queries = this.supabaseCachingService.getAllowlistRecords(args);
         if (single) {
-          return this.supabaseCachingService
-            .getAllowlistRecords(args)
-            .executeTakeFirst();
+          return queries.data.executeTakeFirst();
         }
 
-        return this.supabaseCachingService.getAllowlistRecords(args).execute();
+        return this.supabaseCachingService.db
+          .transaction()
+          .execute(async (transaction) => {
+            const dataRes = await transaction.executeQuery(queries.data);
+            const countRes = await transaction.executeQuery(queries.count);
+            return {
+              data: dataRes.rows,
+              count: countRes.rows[0].count,
+            };
+          });
       } catch (e) {
         const error = e as Error;
         throw new Error(
@@ -151,15 +191,21 @@ export function createBaseResolver<T extends ClassType>(
       );
 
       try {
+        const queries = this.supabaseCachingService.getAttestationSchemas(args);
         if (single) {
-          return this.supabaseCachingService
-            .getAttestationSchemas(args)
-            .executeTakeFirst();
+          return queries.data.executeTakeFirst();
         }
 
-        return this.supabaseCachingService
-          .getAttestationSchemas(args)
-          .execute();
+        return this.supabaseCachingService.db
+          .transaction()
+          .execute(async (transaction) => {
+            const dataRes = await transaction.executeQuery(queries.data);
+            const countRes = await transaction.executeQuery(queries.count);
+            return {
+              data: dataRes.rows,
+              count: countRes.rows[0].count,
+            };
+          });
       } catch (e) {
         const error = e as Error;
         throw new Error(
@@ -174,17 +220,22 @@ export function createBaseResolver<T extends ClassType>(
       );
 
       try {
+        const queries = this.supabaseCachingService.getAttestations(args);
         if (single) {
-          const res = await this.supabaseCachingService
-            .getAttestations(args)
-            .executeTakeFirst();
+          const res = await queries.data.executeTakeFirst();
           return res ? this.parseAttestation(res) : null;
         }
 
-        const res = await this.supabaseCachingService
-          .getAttestations(args)
-          .execute();
-        return res ? res?.map(this.parseAttestation) : [];
+        return this.supabaseCachingService.db
+          .transaction()
+          .execute(async (transaction) => {
+            const dataRes = await transaction.executeQuery(queries.data);
+            const countRes = await transaction.executeQuery(queries.count);
+            return {
+              data: dataRes ? dataRes.rows?.map(this.parseAttestation) : [],
+              count: countRes.rows[0].count,
+            };
+          });
       } catch (e) {
         const error = e as Error;
         throw new Error(
@@ -197,11 +248,21 @@ export function createBaseResolver<T extends ClassType>(
       console.debug(`[${entityFieldName}Resolver::getSales] Fetching sales`);
 
       try {
+        const queries = this.supabaseCachingService.getSales(args);
         if (single) {
-          return this.supabaseCachingService.getSales(args).executeTakeFirst();
+          return queries.data.executeTakeFirst();
         }
 
-        return this.supabaseCachingService.getSales(args).execute();
+        return this.supabaseCachingService.db
+          .transaction()
+          .execute(async (transaction) => {
+            const dataRes = await transaction.executeQuery(queries.data);
+            const countRes = await transaction.executeQuery(queries.count);
+            return {
+              data: dataRes.rows,
+              count: countRes.rows[0].count,
+            };
+          });
       } catch (e) {
         const error = e as Error;
         throw new Error(

--- a/src/graphql/schemas/resolvers/orderResolver.ts
+++ b/src/graphql/schemas/resolvers/orderResolver.ts
@@ -9,7 +9,6 @@ import {
 import { Order } from "../typeDefs/orderTypeDefs.js";
 import { GetOrdersArgs } from "../args/orderArgs.js";
 import { getHypercertTokenId } from "../../../utils/tokenIds.js";
-import { HypercertBaseType } from "../typeDefs/baseTypes/hypercertBaseType.js";
 import { getAddress } from "viem";
 import { HypercertExchangeClient } from "@hypercerts-org/marketplace-sdk";
 import { ethers } from "ethers";
@@ -52,17 +51,16 @@ class OrderResolver extends OrderBaseResolver {
       // TODO: Update this once array filters are available
       const allHypercerts = await Promise.all(
         allHypercertIds.map(async (hypercertId) => {
-          const hypercertRes = await this.getHypercerts({
-            where: {
-              hypercert_id: {
-                eq: hypercertId,
+          return await this.getHypercerts(
+            {
+              where: {
+                hypercert_id: {
+                  eq: hypercertId,
+                },
               },
             },
-          });
-
-          console.log("Found hypercert for order: ", hypercertRes);
-
-          return hypercertRes?.[0] as HypercertBaseType;
+            true,
+          );
         }),
       ).then((res) =>
         _.keyBy(

--- a/src/graphql/schemas/resolvers/salesResolver.ts
+++ b/src/graphql/schemas/resolvers/salesResolver.ts
@@ -8,7 +8,6 @@ import {
 } from "type-graphql";
 import { Sale } from "../typeDefs/salesTypeDefs.js";
 import { GetSalesArgs } from "../args/salesArgs.js";
-import { HypercertBaseType } from "../typeDefs/baseTypes/hypercertBaseType.js";
 import { createBaseResolver, DataResponse } from "./baseTypes.js";
 
 @ObjectType()
@@ -53,29 +52,28 @@ class SalesResolver extends SalesBaseResolver {
       return null;
     }
 
-    const resultSale = hypercert as HypercertBaseType;
-
-    const uri = resultSale?.uri;
-
-    const metadata = await this.supabaseCachingService
-      .getMetadata({
+    const metadata = await this.getMetadata(
+      {
         where: {
-          uri: {
-            eq: uri,
+          hypercerts: {
+            hypercert_id: {
+              eq: hypercertId,
+            },
           },
         },
-      })
-      .executeTakeFirst();
+      },
+      true,
+    );
 
     if (!metadata) {
       console.warn(
-        `[SalesResolver::hypercert] No metadata found for uri: ${uri}`,
+        `[SalesResolver::hypercert] No metadata found for hypercert: ${hypercertId}`,
       );
       return null;
     }
 
     return {
-      ...resultSale,
+      ...hypercert,
       metadata: metadata || null,
     };
   }

--- a/src/graphql/schemas/typeDefs/allowlistRecordTypeDefs.ts
+++ b/src/graphql/schemas/typeDefs/allowlistRecordTypeDefs.ts
@@ -4,6 +4,7 @@ import { EthBigInt } from "../../scalars/ethBigInt.js";
 
 @ObjectType({
   description: "Records of allow list entries for claimable fractions",
+  simpleResolvers: true,
 })
 class AllowlistRecord extends BasicTypeDef {
   @Field({

--- a/src/graphql/schemas/typeDefs/fractionTypeDefs.ts
+++ b/src/graphql/schemas/typeDefs/fractionTypeDefs.ts
@@ -5,7 +5,10 @@ import GetOrdersResponse from "../resolvers/orderResolver.js";
 import { Metadata } from "./metadataTypeDefs.js";
 import GetSalesResponse from "../resolvers/salesResolver.js";
 
-@ObjectType({ description: "Fraction of an hypercert" })
+@ObjectType({
+  description: "Fraction of an hypercert",
+  simpleResolvers: true,
+})
 class Fraction extends BasicTypeDef {
   claims_id?: string;
 

--- a/src/graphql/schemas/typeDefs/hypercertTypeDefs.ts
+++ b/src/graphql/schemas/typeDefs/hypercertTypeDefs.ts
@@ -21,6 +21,7 @@ class GetOrdersForHypercertResponse extends GetOrdersResponse {
 @ObjectType({
   description:
     "Hypercert with metadata, contract, orders, sales and fraction information",
+  simpleResolvers: true,
 })
 class Hypercert extends HypercertBaseType {
   // Resolved fields

--- a/src/graphql/schemas/typeDefs/metadataTypeDefs.ts
+++ b/src/graphql/schemas/typeDefs/metadataTypeDefs.ts
@@ -7,6 +7,7 @@ import { EthBigInt } from "../../scalars/ethBigInt.js";
 @ObjectType({
   description:
     "Metadata related to the hypercert describing work, impact, timeframes and other relevant information",
+  simpleResolvers: true,
 })
 class Metadata extends BasicTypeDef {
   @Field({ nullable: true, description: "Name of the hypercert" })


### PR DESCRIPTION
When querying using filters, or when using pagination, count should not return the amount or returned rows, but the amount of rows matching the filter params.

This PR:
- Defines dataQuery and countQuery builder
- Implements data fetching buy calling both the data and count query in a single transaction
- Cleans up some business logic