### PR TITLE
Fix/query fractions view

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -81,8 +81,8 @@ type Attestation {
   """Encoded data of the attestation"""
   data: JSON
 
-  """List of hypercerts related to the attestation"""
-  hypercerts: [Hypercert!]
+  """Hypercert related to the attestation"""
+  hypercert: HypercertBaseType
   id: ID!
 
   """Block number at which the attestation was last updated"""
@@ -398,16 +398,21 @@ type GetCollectionsResponse {
   data: [Collection!]
 }
 
+"""Pointer to a contract deployed on a chain"""
 type GetContractsResponse {
   count: Int
   data: [Contract!]
 }
 
+"""Fraction of an hypercert"""
 type GetFractionsResponse {
   count: Int
   data: [Fraction!]
 }
 
+"""
+Hypercert with metadata, contract, orders, sales and fraction information
+"""
 type GetHypercertsResponse {
   count: Int
   data: [Hypercert!]

--- a/src/graphql/schemas/resolvers/attestationResolver.ts
+++ b/src/graphql/schemas/resolvers/attestationResolver.ts
@@ -34,8 +34,8 @@ class AttestationResolver extends AttestationBaseResolver {
     return await this.getAttestations(args);
   }
 
-  @FieldResolver({ nullable: true })
-  async hypercerts(@Root() attestation: Attestation) {
+  @FieldResolver()
+  async hypercert(@Root() attestation: Attestation) {
     if (!attestation.data) return null;
 
     const { success, data } = HypercertPointer.safeParse(attestation.data);

--- a/src/graphql/schemas/resolvers/baseTypes.ts
+++ b/src/graphql/schemas/resolvers/baseTypes.ts
@@ -137,6 +137,7 @@ export function createBaseResolver<T extends ClassType>(
           .execute(async (transaction) => {
             const dataRes = await transaction.executeQuery(queries.data);
             const countRes = await transaction.executeQuery(queries.count);
+
             return {
               data: dataRes.rows,
               count: countRes.rows[0].count,

--- a/src/graphql/schemas/resolvers/contractResolver.ts
+++ b/src/graphql/schemas/resolvers/contractResolver.ts
@@ -3,7 +3,7 @@ import { Contract } from "../typeDefs/contractTypeDefs.js";
 import { GetContractsArgs } from "../args/contractArgs.js";
 import { createBaseResolver, DataResponse } from "./baseTypes.js";
 
-@ObjectType()
+@ObjectType({ description: "Pointer to a contract deployed on a chain" })
 export default class GetContractsResponse extends DataResponse(Contract) {}
 
 const ContractBaseResolver = createBaseResolver("contract");

--- a/src/graphql/schemas/resolvers/fractionResolver.ts
+++ b/src/graphql/schemas/resolvers/fractionResolver.ts
@@ -11,7 +11,7 @@ import { GetFractionsArgs } from "../args/fractionArgs.js";
 import { parseClaimOrFractionId } from "@hypercerts-org/sdk";
 import { createBaseResolver, DataResponse } from "./baseTypes.js";
 
-@ObjectType()
+@ObjectType({ description: "Fraction of an hypercert" })
 export default class GetFractionsResponse extends DataResponse(Fraction) {}
 
 const FractionBaseResolver = createBaseResolver("fraction");

--- a/src/graphql/schemas/resolvers/hypercertResolver.ts
+++ b/src/graphql/schemas/resolvers/hypercertResolver.ts
@@ -17,7 +17,10 @@ import { Database } from "../../../types/supabaseData.js";
 import { createBaseResolver, DataResponse } from "./baseTypes.js";
 import "reflect-metadata";
 
-@ObjectType()
+@ObjectType({
+  description:
+    "Hypercert with metadata, contract, orders, sales and fraction information",
+})
 export default class GetHypercertsResponse extends DataResponse(Hypercert) {}
 
 const HypercertBaseResolver = createBaseResolver("hypercert");

--- a/src/graphql/schemas/resolvers/hypercertResolver.ts
+++ b/src/graphql/schemas/resolvers/hypercertResolver.ts
@@ -69,12 +69,12 @@ class HypercertResolver extends HypercertBaseResolver {
 
   @FieldResolver()
   async fractions(@Root() hypercert: Hypercert) {
-    if (!hypercert.id) {
+    if (!hypercert.hypercert_id) {
       return;
     }
 
     return await this.getFractions(
-      { where: { hypercerts: { id: { eq: hypercert.id } } } },
+      { where: { hypercert_id: { eq: hypercert.hypercert_id } } },
       false,
     );
   }

--- a/src/graphql/schemas/typeDefs/attestationTypeDefs.ts
+++ b/src/graphql/schemas/typeDefs/attestationTypeDefs.ts
@@ -1,76 +1,17 @@
-import { Field, ID, ObjectType } from "type-graphql";
-import { GraphQLJSON } from "graphql-scalars";
-import type { Json } from "../../../types/supabaseCaching.js";
-import { Hypercert } from "./hypercertTypeDefs.js";
-import { BasicTypeDef } from "./baseTypes/basicTypeDef.js";
-import { EthBigInt } from "../../scalars/ethBigInt.js";
+import { Field, ObjectType } from "type-graphql";
+import { AttestationBaseType } from "./baseTypes/attestationBaseType.js";
+import { HypercertBaseType } from "./baseTypes/hypercertBaseType.js";
 
-@ObjectType({ description: "Attestation on the Ethereum Attestation Service" })
-class Attestation extends BasicTypeDef {
-  @Field(() => ID, {
+@ObjectType({
+  description: "Attestation on the Ethereum Attestation Service",
+  simpleResolvers: true,
+})
+class Attestation extends AttestationBaseType {
+  @Field(() => HypercertBaseType, {
     nullable: true,
-    description: "ID referencing the supported EAS schema in the database",
+    description: "Hypercert related to the attestation",
   })
-  supported_schemas_id?: string;
-  @Field(() => ID, {
-    nullable: true,
-    description: "Unique identifier for the attestation on EAS",
-  })
-  uid?: string;
-
-  @Field(() => EthBigInt, {
-    nullable: true,
-    description: "Block number at which the attestation was created",
-  })
-  creation_block_number?: bigint | number | string;
-  @Field(() => EthBigInt, {
-    nullable: true,
-    description: "Timestamp at which the attestation was created",
-  })
-  creation_block_timestamp?: bigint | number | string;
-  @Field(() => EthBigInt, {
-    nullable: true,
-    description: "Block number at which the attestation was last updated",
-  })
-  last_update_block_number?: bigint | number | string;
-  @Field(() => EthBigInt, {
-    nullable: true,
-    description: "Timestamp at which the attestation was last updated",
-  })
-  last_update_block_timestamp?: bigint | number | string;
-
-  @Field({
-    nullable: true,
-    description: "Address of the creator of the attestation",
-  })
-  attester?: string;
-  @Field({
-    nullable: true,
-    description: "Address of the recipient of the attestation",
-  })
-  recipient?: string;
-  @Field({
-    nullable: true,
-    description: "Address of the resolver contract for the attestation",
-  })
-  resolver?: string;
-  @Field({
-    nullable: true,
-    description:
-      "Unique identifier of the EAS schema used to create the attestation",
-  })
-  schema?: string;
-  @Field(() => GraphQLJSON, {
-    nullable: true,
-    description: "Encoded data of the attestation",
-  })
-  data?: Json;
-
-  @Field(() => [Hypercert], {
-    nullable: true,
-    description: "List of hypercerts related to the attestation",
-  })
-  hypercerts?: Hypercert[];
+  hypercert?: HypercertBaseType;
 }
 
 export { Attestation };

--- a/src/graphql/schemas/typeDefs/baseTypes/attestationBaseType.ts
+++ b/src/graphql/schemas/typeDefs/baseTypes/attestationBaseType.ts
@@ -1,0 +1,69 @@
+import { Field, ID, ObjectType } from "type-graphql";
+import { BasicTypeDef } from "./basicTypeDef.js";
+import { EthBigInt } from "../../../scalars/ethBigInt.js";
+import type { Json } from "../../../../types/supabaseCaching.js";
+import { GraphQLJSON } from "graphql-scalars";
+
+@ObjectType()
+class AttestationBaseType extends BasicTypeDef {
+  @Field(() => ID, {
+    nullable: true,
+    description: "ID referencing the supported EAS schema in the database",
+  })
+  supported_schemas_id?: string;
+  @Field(() => ID, {
+    nullable: true,
+    description: "Unique identifier for the attestation on EAS",
+  })
+  uid?: string;
+
+  @Field(() => EthBigInt, {
+    nullable: true,
+    description: "Block number at which the attestation was created",
+  })
+  creation_block_number?: bigint | number | string;
+  @Field(() => EthBigInt, {
+    nullable: true,
+    description: "Timestamp at which the attestation was created",
+  })
+  creation_block_timestamp?: bigint | number | string;
+  @Field(() => EthBigInt, {
+    nullable: true,
+    description: "Block number at which the attestation was last updated",
+  })
+  last_update_block_number?: bigint | number | string;
+  @Field(() => EthBigInt, {
+    nullable: true,
+    description: "Timestamp at which the attestation was last updated",
+  })
+  last_update_block_timestamp?: bigint | number | string;
+
+  @Field({
+    nullable: true,
+    description: "Address of the creator of the attestation",
+  })
+  attester?: string;
+  @Field({
+    nullable: true,
+    description: "Address of the recipient of the attestation",
+  })
+  recipient?: string;
+  @Field({
+    nullable: true,
+    description: "Address of the resolver contract for the attestation",
+  })
+  resolver?: string;
+  @Field({
+    nullable: true,
+    description:
+      "Unique identifier of the EAS schema used to create the attestation",
+  })
+  schema?: string;
+  @Field(() => GraphQLJSON, {
+    nullable: true,
+    description: "Encoded data of the attestation",
+  })
+  data?: Json;
+}
+
+export { AttestationBaseType };

--- a/src/services/SupabaseCachingService.ts
+++ b/src/services/SupabaseCachingService.ts
@@ -129,16 +129,14 @@ export class SupabaseCachingService {
         return this.db.selectFrom("contracts").selectAll();
       case "fractions":
       case "fractions_view":
-        return this.db
-          .selectFrom("fractions_view")
-          .selectAll()
-          .$if(args.where?.hypercerts, (qb) =>
-            qb.leftJoin(
-              "claims",
-              "claims.hypercert_id",
-              "fractions_view.hypercert_id",
-            ),
-          );
+        return this.db.selectFrom("fractions_view").selectAll();
+      // .$if(args.where?.hypercerts, (qb) =>
+      //   qb.leftJoin(
+      //     "claims",
+      //     "claims.hypercert_id",
+      //     "fractions_view.hypercert_id",
+      //   ),
+      // );
       case "metadata":
         return this.db
           .selectFrom("metadata")
@@ -184,8 +182,8 @@ export class SupabaseCachingService {
           .select((expressionBuilder) => {
             return expressionBuilder.fn.countAll().as("count");
           });
-      case "hypercerts":
       case "claims":
+      case "hypercerts":
         return this.db
           .selectFrom("claims")
           .$if(args.where?.metadata, (qb) =>
@@ -211,9 +209,6 @@ export class SupabaseCachingService {
       case "fractions_view":
         return this.db
           .selectFrom("fractions_view")
-          .$if(args.where?.hypercerts, (qb) =>
-            qb.innerJoin("claims", "claims.id", "fractions_view.claims_id"),
-          )
           .select((expressionBuilder) => {
             return expressionBuilder.fn.countAll().as("count");
           });

--- a/src/services/SupabaseCachingService.ts
+++ b/src/services/SupabaseCachingService.ts
@@ -110,7 +110,7 @@ export class SupabaseCachingService {
       case "claims":
         return this.db
           .selectFrom("claims")
-          .selectAll("claims")
+          .selectAll("claims") // Select all columns from the claims table
           .$if(args.where?.metadata, (qb) =>
             qb.innerJoin("metadata", "metadata.uri", "claims.uri"),
           )
@@ -118,7 +118,9 @@ export class SupabaseCachingService {
             qb.innerJoin("attestations", "attestations.claims_id", "claims.id"),
           )
           .$if(args.where?.fractions, (qb) =>
-            qb.innerJoin("fractions", "fractions.claims_id", "claims.id"),
+            qb.innerJoin("fractions_view", (join) =>
+              join.on("fractions_view.claims_id", "=", "claims.id"),
+            ),
           )
           .$if(args.where?.contract, (qb) =>
             qb.innerJoin("contracts", "contracts.id", "claims.contracts_id"),

--- a/src/services/SupabaseCachingService.ts
+++ b/src/services/SupabaseCachingService.ts
@@ -131,7 +131,11 @@ export class SupabaseCachingService {
           .selectFrom("fractions_view")
           .selectAll()
           .$if(args.where?.hypercerts, (qb) =>
-            qb.innerJoin("claims", "claims.id", "fractions_view.claims_id"),
+            qb.leftJoin(
+              "claims",
+              "claims.hypercert_id",
+              "fractions_view.hypercert_id",
+            ),
           );
       case "metadata":
         return this.db

--- a/src/types/graphql-env.d.ts
+++ b/src/types/graphql-env.d.ts
@@ -375,17 +375,11 @@ export type introspection = {
             "args": []
           },
           {
-            "name": "hypercerts",
+            "name": "hypercert",
             "type": {
-              "kind": "LIST",
-              "ofType": {
-                "kind": "NON_NULL",
-                "ofType": {
-                  "kind": "OBJECT",
-                  "name": "Hypercert",
-                  "ofType": null
-                }
-              }
+              "kind": "OBJECT",
+              "name": "HypercertBaseType",
+              "ofType": null
             },
             "args": []
           },


### PR DESCRIPTION
* Return single hypercert on attestations.hypercert queries
* Remove cross-referencing between hypercerts and fractions resolvers
* Cleanup up query building joins to prevent conflicting columns
* restores fraction.owner_address to the fraction owner and not the claim owner