### PR TITLE
Safe integration for profile updates

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "@hypercerts-org/sdk": "2.3.0",
     "@ipld/car": "^5.2.5",
     "@openzeppelin/merkle-tree": "^1.0.5",
+    "@safe-global/api-kit": "^2.5.4",
     "@sentry/integrations": "^7.114.0",
     "@sentry/node": "^8.2.1",
     "@sentry/profiling-node": "^8.2.1",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "@ipld/car": "^5.2.5",
     "@openzeppelin/merkle-tree": "^1.0.5",
     "@safe-global/api-kit": "^2.5.4",
+    "@safe-global/protocol-kit": "^5.0.4",
     "@sentry/integrations": "^7.114.0",
     "@sentry/node": "^8.2.1",
     "@sentry/profiling-node": "^8.2.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,6 +29,9 @@ importers:
       '@openzeppelin/merkle-tree':
         specifier: ^1.0.5
         version: 1.0.5
+      '@safe-global/api-kit':
+        specifier: ^2.5.4
+        version: 2.5.4(encoding@0.1.13)(typescript@5.5.3)(zod@3.23.8)
       '@sentry/integrations':
         specifier: ^7.114.0
         version: 7.114.0
@@ -314,6 +317,7 @@ packages:
 
   '@ardatan/relay-compiler@12.0.0':
     resolution: {integrity: sha512-9anThAaj1dQr6IGmzBMcfzOQKTa5artjuPmw8NYK/fiGEMjADbSguBY2FMDykt+QhilR3wc9VA/3yVju7JHg7Q==}
+    hasBin: true
     peerDependencies:
       graphql: '*'
 
@@ -443,10 +447,12 @@ packages:
   '@babel/parser@7.23.9':
     resolution: {integrity: sha512-9tcKgqKbs3xGJ+NtKF2ndOBBLVwPjl1SHxPQkd36r3Dlirw3xWUeGaTbqr7uGZcTaxkVNwc+03SVP7aCdWrTlA==}
     engines: {node: '>=6.0.0'}
+    hasBin: true
 
   '@babel/parser@7.24.7':
     resolution: {integrity: sha512-9uUYRm6OqQrCqQdG1iCBwBPZgN8ciDBro2nIOFaiRz1/BCxaI7CNvQbDHvsArAC7Tw9Hda/B3U+6ui9u4HWXPw==}
     engines: {node: '>=6.0.0'}
+    hasBin: true
 
   '@babel/plugin-proposal-class-properties@7.18.6':
     resolution: {integrity: sha512-cumfXOF0+nzZrrN8Rf0t7M+tF6sZc7vhQwYQck9q1/5w2OExlD+b4v4RpMJFaV1Z7WcDRgO6FqvxqxGlwo+RHQ==}
@@ -631,6 +637,7 @@ packages:
   '@commitlint/cli@19.4.1':
     resolution: {integrity: sha512-EerFVII3ZcnhXsDT9VePyIdCJoh3jEzygN1L37MjQXgPfGS6fJTWL/KHClVMod1d8w94lFC3l4Vh/y5ysVAz2A==}
     engines: {node: '>=v18'}
+    hasBin: true
 
   '@commitlint/config-conventional@19.4.1':
     resolution: {integrity: sha512-D5S5T7ilI5roybWGc8X35OBlRXLAwuTseH1ro0XgqkOWrhZU8yOwBOslrNmSDlTXhXLq8cnfhQyC42qaUCzlXA==}
@@ -886,6 +893,7 @@ packages:
   '@ethereumjs/rlp@4.0.1':
     resolution: {integrity: sha512-tqsQiBQDQdmPWE1xkkBq4rlSW5QZpLOUJ5RJh2/9fug+q9tnUhuZoVLk7s0scUIKTOzEtR72DFBXI4WiZcMpvw==}
     engines: {node: '>=14'}
+    hasBin: true
 
   '@ethereumjs/util@8.1.0':
     resolution: {integrity: sha512-zQ0IqbdX8FZ9aw11vP+dZkKDkS+kgIvQPHnSAXzP9pLu+Rfu3D3XEeLbicvoXJTYnhZiPmsZUxgdzXwNKxRPbA==}
@@ -1018,6 +1026,7 @@ packages:
 
   '@graphql-codegen/cli@5.0.2':
     resolution: {integrity: sha512-MBIaFqDiLKuO4ojN6xxG9/xL9wmfD3ZjZ7RsPjwQnSHBCUXnEkdKvX+JVpx87Pq29Ycn8wTJUguXnTZ7Di0Mlw==}
+    hasBin: true
     peerDependencies:
       '@parcel/watcher': ^2.1.0
       graphql: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0
@@ -1979,6 +1988,7 @@ packages:
 
   '@openzeppelin/hardhat-upgrades@3.2.1':
     resolution: {integrity: sha512-Zy5M3QhkzwGdpzQmk+xbWdYOGJWjoTvwbBKYLhctu9B91DoprlhDRaZUwCtunwTdynkTDGdVfGr0kIkvycyKjw==}
+    hasBin: true
     peerDependencies:
       '@nomicfoundation/hardhat-ethers': ^3.0.0
       '@nomicfoundation/hardhat-verify': ^2.0.0
@@ -1996,6 +2006,7 @@ packages:
 
   '@openzeppelin/upgrades-core@1.35.1':
     resolution: {integrity: sha512-FzbOzMrrNtXpL+DoM6jtOGZOvUdp6F4KTsb0niqfrd2BxMecL9fUA0aupi09p1Of+9BELcYozX/Gt7tr91Z2TA==}
+    hasBin: true
 
   '@peculiar/asn1-schema@2.3.8':
     resolution: {integrity: sha512-ULB1XqHKx1WBU/tTFIA+uARuRoBVZ4pNdOA878RDrRbBfBGcSzi5HBkdScC6ZbHn8z7L8gmKCgPC1LHRrP46tA==}
@@ -2165,6 +2176,21 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@safe-global/api-kit@2.5.4':
+    resolution: {integrity: sha512-L12qTaEQdQqdlPhsjC+JCpH5qxphyegPptrc98cRFnxsES0Dz3i/2df7kSAIntaYIP4aFEbulpVwOjOgWf+hDQ==}
+
+  '@safe-global/protocol-kit@5.0.4':
+    resolution: {integrity: sha512-e2BhyiS/7jMzJY8oNpkMIHWAViENyL42/SAvFOcFsEc6JBvnh+4GGvLRwLVEiQ8e+54sJinRjo1/iTCrTIoqOQ==}
+
+  '@safe-global/safe-deployments@1.37.18':
+    resolution: {integrity: sha512-flX/TtgsbKp5qLJSSy/v7bcdtTsml6F9Vyf/JnG1Zfeto5aDeNYlvzljHAd8atnbOiggrZ8z5jyvdlh6njsXfw==}
+
+  '@safe-global/safe-modules-deployments@2.2.4':
+    resolution: {integrity: sha512-m396ZrBPhZVYkapTTIuizyOOtoZsCKbicl0ztgDFfDbi7KbS6AtDP6cV89AYosQxUQS+v0q4ksQd30/j3L1BtQ==}
+
+  '@safe-global/types-kit@1.0.0':
+    resolution: {integrity: sha512-jZNUeHbWobeVrURbcEvfas4Q1IDasQni5UYm2umUtAR6SBDazp1kGni8IjZPRKq3+8q+fYwu9FmKpX50rUYn3w==}
+
   '@sagold/json-pointer@5.1.2':
     resolution: {integrity: sha512-+wAhJZBXa6MNxRScg6tkqEbChEHMgVZAhTHVJ60Y7sbtXtu9XA49KfUkdWlS2x78D6H9nryiKePiYozumauPfA==}
 
@@ -2252,6 +2278,7 @@ packages:
   '@sentry/profiling-node@8.2.1':
     resolution: {integrity: sha512-oHjKXu8rROlaM1GZHQNyt8lG/58XSD6lUHgxx33IuqUTZjIzise8AB7fE1fzg4+JNFZITag6zzYqrQqPGSN3HQ==}
     engines: {node: '>=14.18'}
+    hasBin: true
 
   '@sentry/tracing@5.30.0':
     resolution: {integrity: sha512-dUFowCr0AIMwiLD7Fs314Mdzcug+gBVo/+NCMyDw8tFxJkwWAKl7Qa2OZxLQ0ZHjakcj1hNKfCQJ9rhyfOl4Aw==}
@@ -2319,6 +2346,7 @@ packages:
   '@snaplet/seed@0.97.20':
     resolution: {integrity: sha512-+lnqESgwP92O1266vsTyoRgrg4hMCUTybBUxDT1ICMBFcvdjgwcOaUt8Xjj81YvxYkZlu5+TTBIjyNQT4nP4jQ==}
     engines: {node: '>=18.5.0'}
+    hasBin: true
     peerDependencies:
       '@prisma/client': '>=5'
       '@snaplet/copycat': '>=2'
@@ -2377,6 +2405,7 @@ packages:
   '@swc/cli@0.3.12':
     resolution: {integrity: sha512-h7bvxT+4+UDrLWJLFHt6V+vNAcUNii2G4aGSSotKz1ECEk4MyEh5CWxmeSscwuz5K3i+4DWTgm4+4EyMCQKn+g==}
     engines: {node: '>= 16.14.0'}
+    hasBin: true
     peerDependencies:
       '@swc/core': ^1.2.66
       chokidar: ^3.5.1
@@ -2573,6 +2602,7 @@ packages:
   '@tsoa/cli@6.2.1':
     resolution: {integrity: sha512-SS28cvL2uurau2PZbBO8Ks6O9LF497iMlnUfMr7hffbgxh81SftfG+qvddeniNw0ttSB593Mljvv+fPabEbrfQ==}
     engines: {node: '>=18.0.0', yarn: '>=1.9.4'}
+    hasBin: true
 
   '@tsoa/runtime@6.2.1':
     resolution: {integrity: sha512-YOA7ha6W6GQsSr3Pvb5omb5AwizvQd7GUu54Oi2TjNWYOzfczBROZonReMfKBiNULiZBDmEc5r1Hs+Kbbfjgyw==}
@@ -2953,12 +2983,24 @@ packages:
 
   JSONStream@1.3.5:
     resolution: {integrity: sha512-E+iruNOY8VV9s4JEbe1aNEm6MiszPRr/UfcHMz0TQh1BXSxHK+ASV1R6W4HpjBhSeS+54PIsAMCBmwD06LLsqQ==}
+    hasBin: true
 
   abbrev@1.1.1:
     resolution: {integrity: sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==}
 
   abitype@0.10.0:
     resolution: {integrity: sha512-QvMHEUzgI9nPj9TWtUGnS2scas80/qaL5PBxGdwWhhvzqXfOph+IEiiiWrzuisu3U3JgDQVruW9oLbJoQ3oZ3A==}
+    peerDependencies:
+      typescript: '>=5.0.4'
+      zod: ^3 >=3.22.0
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+      zod:
+        optional: true
+
+  abitype@1.0.6:
+    resolution: {integrity: sha512-MMSqYh4+C/aVqI2RQaWqbvI4Kxo5cQV40WQ4QFtDnNzCkqChm8MuENhElmynZlO0qUy/ObkEUaXtKqYnx1Kp3A==}
     peerDependencies:
       typescript: '>=5.0.4'
       zod: ^3 >=3.22.0
@@ -3009,6 +3051,7 @@ packages:
   acorn@8.11.3:
     resolution: {integrity: sha512-Y9rRfJG5jcKOE0CLisYbojUjIrIEE7AGMzA/Sm4BslANhbS+cDMpgBdcPT91oJ7OuJ9hYJBx59RjbhxVnrF8Xg==}
     engines: {node: '>=0.4.0'}
+    hasBin: true
 
   actor@2.3.1:
     resolution: {integrity: sha512-ST/3wnvcP2tKDXnum7nLCLXm+/rsf8vPocXH2Fre6D8FQwNkGDd4JEitBlXj007VQJfiGYRQvXqwOBZVi+JtRg==}
@@ -3328,6 +3371,7 @@ packages:
   browserslist@4.23.0:
     resolution: {integrity: sha512-QW8HiM1shhT2GuzkvklfjcKDiWFXHOeFCIA/huJPwHsslwcydgk7X+z2zXpEijP98UCY7HbubZt5J2Zgvf0CaQ==}
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
+    hasBin: true
 
   bs58@4.0.1:
     resolution: {integrity: sha512-Ok3Wdf5vOIlBrgCvTq96gBkJw+JUEzdBgyaza5HLtPm7yTHkjRy8+JzNyHF7BHa0bNWOQIp3m5YF0nnFcOIKLw==}
@@ -3421,6 +3465,7 @@ packages:
 
   cborg@4.0.6:
     resolution: {integrity: sha512-McNIJHMQKQv/WgSE1JqWfqS4kaeN5g9GRA5MqVCt1+66TGsywkpzBUywpZ/HWF3Ik8yudSR+ZPlq6TRBEZXQyA==}
+    hasBin: true
 
   chai-assertions-count@1.0.2:
     resolution: {integrity: sha512-TnhoI68Mh7GYsdrvQuxK+kKOTfEXQZjePP8lTvYhXGv8KOKY+GaOY3PemMq8mBAa0gqQRKsISdi7QFJ/Lxdt+g==}
@@ -3637,6 +3682,7 @@ packages:
   concurrently@8.2.2:
     resolution: {integrity: sha512-1dP4gpXFhei8IOtlXRE/T/4H88ElHgTiUzh71YUmtjTEHMSRS2Z/fgOxHSxxusGHogsRfxNq1vyAwxSC+EVyDg==}
     engines: {node: ^14.13.0 || >=16.0.0}
+    hasBin: true
 
   conf@11.0.2:
     resolution: {integrity: sha512-jjyhlQ0ew/iwmtwsS2RaB6s8DBifcE2GYBEaw2SJDUY/slJJbNfY4GlDVzOs/ff8cM/Wua5CikqXgbFl5eu85A==}
@@ -3671,6 +3717,7 @@ packages:
   conventional-commits-parser@5.0.0:
     resolution: {integrity: sha512-ZPMl0ZJbw74iS9LuX9YIAiW8pfM5p3yh2o/NbXHbkFuZzY5jvdi5jFycEOkmBW5H5I7nA+D6f3UcsCLP2vvSEA==}
     engines: {node: '>=16'}
+    hasBin: true
 
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
@@ -3979,6 +4026,7 @@ packages:
 
   ebnf@1.9.1:
     resolution: {integrity: sha512-uW2UKSsuty9ANJ3YByIQE4ANkD8nqUPO7r6Fwcc1ADKPe9FRdcPpMl3VEput4JSvKBJ4J86npIC2MLP0pYkCuw==}
+    hasBin: true
 
   ee-first@1.1.1:
     resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
@@ -4071,6 +4119,7 @@ packages:
   esbuild@0.19.11:
     resolution: {integrity: sha512-HJ96Hev2hX/6i5cDVwcqiJBBtuo9+FeIJOtZ9W1kA5M6AMJRHUZlpYZ1/SbEwtO0ioNAW8rUooVpC/WehY2SfA==}
     engines: {node: '>=12'}
+    hasBin: true
 
   escalade@3.1.1:
     resolution: {integrity: sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==}
@@ -4102,6 +4151,7 @@ packages:
   eslint@8.56.0:
     resolution: {integrity: sha512-Go19xM6T9puCOWntie1/P997aXxFsOi37JIHRWI514Hc6ZnaHGKY9xFhrU65RT6CcBEzZoGG1e6Nq+DT04ZtZQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    hasBin: true
 
   espree@9.6.1:
     resolution: {integrity: sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ==}
@@ -4478,10 +4528,12 @@ packages:
 
   giget@1.2.3:
     resolution: {integrity: sha512-8EHPljDvs7qKykr6uw8b+lqLiUc/vUg+KVTI0uND4s63TdsZM2Xus3mflvF0DDG9SiM4RlCkFGL+7aAjRmV7KA==}
+    hasBin: true
 
   git-raw-commits@4.0.0:
     resolution: {integrity: sha512-ICsMM1Wk8xSGMowkOmPrzo2Fgmfo4bMHLNX6ytHjajRJUqvHOw/TFapQ+QG75c3X/tTDDhOSRPGC52dDbNM8FQ==}
     engines: {node: '>=16'}
+    hasBin: true
 
   glob-parent@5.1.2:
     resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
@@ -4494,6 +4546,7 @@ packages:
   glob@10.3.10:
     resolution: {integrity: sha512-fa46+tv1Ak0UPK1TOy/pZrIybNNt4HCv7SDzwyfiOZkvZLEbjsZkJBPtDHVshZjbecAoAGSC20MjLDG/qr679g==}
     engines: {node: '>=16 || 14 >=14.17'}
+    hasBin: true
 
   glob@7.2.0:
     resolution: {integrity: sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==}
@@ -4533,6 +4586,7 @@ packages:
 
   gql.tada@1.8.3:
     resolution: {integrity: sha512-0H81I3M54jKTDHbnNWhXDf57Ie2d2raxnFCc93zdYjXHnrXe522jrio9AAFwqBlGx/xtaP3ILSSUw7J9H31LAA==}
+    hasBin: true
     peerDependencies:
       typescript: ^5.0.0
 
@@ -4608,6 +4662,7 @@ packages:
   handlebars@4.7.8:
     resolution: {integrity: sha512-vafaFqs8MZkRrSX7sFVUdo3ap/eNiLnb4IakshzvP56X5Nr1iGKAIqdX6tMlm6HcNRIkr6AxO5jFEoJzzpT8aQ==}
     engines: {node: '>=0.4.7'}
+    hasBin: true
 
   hardhat-deploy@0.11.45:
     resolution: {integrity: sha512-aC8UNaq3JcORnEUIwV945iJuvBwi65tjHVDU3v6mOcqik7WAzHVCJ7cwmkkipsHrWysrB5YvGF1q9S1vIph83w==}
@@ -4666,6 +4721,7 @@ packages:
 
   he@1.2.0:
     resolution: {integrity: sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==}
+    hasBin: true
 
   header-case@2.0.4:
     resolution: {integrity: sha512-H/vuk5TEEVZwrR0lp2zed9OCo1uAILMlx0JEMgC26rzyJJ3N1v6XkwHHXJQdR2doSjcGPM6OKPYoJgf0plJ11Q==}
@@ -4707,6 +4763,7 @@ packages:
   husky@9.1.5:
     resolution: {integrity: sha512-rowAVRUBfI0b4+niA4SJMhfQwc107VLkBUgEYYAOQAbqDCnra1nYh83hF/MDmhYs9t9n1E3DuKOrs2LYNC+0Ag==}
     engines: {node: '>=18'}
+    hasBin: true
 
   iconv-lite@0.4.24:
     resolution: {integrity: sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==}
@@ -4851,6 +4908,7 @@ packages:
   is-docker@2.2.1:
     resolution: {integrity: sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==}
     engines: {node: '>=8'}
+    hasBin: true
 
   is-electron@2.2.2:
     resolution: {integrity: sha512-FO/Rhvz5tuw4MCWkpMzHFKWD2LsfHzIb7i6MdPYZ/KW7AlxawyLkqdy+jPZP1WubqEADE3O4FUENlJHDfQASRg==}
@@ -5032,6 +5090,11 @@ packages:
     peerDependencies:
       ws: '*'
 
+  isows@1.0.6:
+    resolution: {integrity: sha512-lPHCayd40oW98/I0uvgaHKWCSvkzY27LjWLbtzOm64yQ+G3Q5npjjbdppU65iZXkK1Zt+kH9pfegli0AYfwYYw==}
+    peerDependencies:
+      ws: '*'
+
   it-all@1.0.6:
     resolution: {integrity: sha512-3cmCc6Heqe3uWi3CVM/k51fa/XbMFpQVzFoDsV0IZNHSQDyAXl3c4MjHkFX5kF3922OGj7Myv1nSEUgRtcuM1A==}
 
@@ -5053,6 +5116,7 @@ packages:
 
   jiti@1.21.0:
     resolution: {integrity: sha512-gFqAIbuKyyso/3G2qhiO2OM6shY6EPP/R0+mkDbyspxKazh8BXDC5FiFsUjlczgdNz/vfra0da2y+aHrusLG/Q==}
+    hasBin: true
 
   jose@5.2.3:
     resolution: {integrity: sha512-KUXdbctm1uHVL8BYhnyHkgp3zDX5KW8ZhAKVFEfUbU2P8Alpzjb+48hHvjOdQIyPshoblhzsuqOwEEAbtHVirA==}
@@ -5071,10 +5135,12 @@ packages:
 
   js-yaml@4.1.0:
     resolution: {integrity: sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==}
+    hasBin: true
 
   jsesc@2.5.2:
     resolution: {integrity: sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==}
     engines: {node: '>=4'}
+    hasBin: true
 
   json-buffer@3.0.1:
     resolution: {integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==}
@@ -5115,6 +5181,7 @@ packages:
   json5@2.2.3:
     resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
     engines: {node: '>=6'}
+    hasBin: true
 
   jsonc-parser@3.2.0:
     resolution: {integrity: sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w==}
@@ -5181,6 +5248,7 @@ packages:
   lint-staged@15.2.9:
     resolution: {integrity: sha512-BZAt8Lk3sEnxw7tfxM7jeZlPRuT4M68O0/CwZhhaw6eeWu0Lz5eERE3m386InivXB64fp/mDID452h48tvKlRQ==}
     engines: {node: '>=18.12.0'}
+    hasBin: true
 
   listr2@4.0.5:
     resolution: {integrity: sha512-juGHV1doQdpNT3GSTs9IUN43QJb7KHdF9uqg7Vufs/tG9VTzpFphqF4pm/ICdAABGQxsyNn9CiYA3StkI6jpwA==}
@@ -5283,6 +5351,7 @@ packages:
 
   loose-envify@1.4.0:
     resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
+    hasBin: true
 
   loupe@2.3.7:
     resolution: {integrity: sha512-zSMINGVYkdpYSOBmLi0D1Uo7JU9nVdQKrHxC8eYlV+9YKK9WePqAlL7lSlorG/U2Fw1w0hTBmaa/jrQ3UbPHtA==}
@@ -5337,6 +5406,7 @@ packages:
 
   markdown-it@14.1.0:
     resolution: {integrity: sha512-a54IwgWPaeBCAAsv13YgmALOF1elABB08FxO9i+r4VFk5Vl4pKokRPeX8u5TCgSsPi6ec1otfLjdOpVcgbpshg==}
+    hasBin: true
 
   match-all@1.2.6:
     resolution: {integrity: sha512-0EESkXiTkWzrQQntBu2uzKvLu6vVkUGz40nGPbSZuegcfE5UuSzNjLaIu76zJWuaT/2I3Z/8M06OlUOZLGwLlQ==}
@@ -5422,6 +5492,7 @@ packages:
   mime@1.6.0:
     resolution: {integrity: sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==}
     engines: {node: '>=4'}
+    hasBin: true
 
   mimic-fn@2.1.0:
     resolution: {integrity: sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==}
@@ -5505,18 +5576,22 @@ packages:
 
   mkdirp@0.5.6:
     resolution: {integrity: sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==}
+    hasBin: true
 
   mkdirp@1.0.4:
     resolution: {integrity: sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==}
     engines: {node: '>=10'}
+    hasBin: true
 
   mkdirp@2.1.6:
     resolution: {integrity: sha512-+hEnITedc8LAtIP9u3HJDFIdcLV2vXP33sqLLIzkv1Db1zO/1OxbvYf0Y1OC/S/Qo5dxHXepofhmxL02PsKe+A==}
     engines: {node: '>=10'}
+    hasBin: true
 
   mkdirp@3.0.1:
     resolution: {integrity: sha512-+NsyUUAZDmo6YVHzL/stxSu3t9YS1iljliy3BSDrXJ/dkn1KYdmtZODGGjLcc9XLgVVpH4KshHB8XmZgMhaBXg==}
     engines: {node: '>=10'}
+    hasBin: true
 
   mlly@1.4.2:
     resolution: {integrity: sha512-i/Ykufi2t1EZ6NaPLdfnZk2AX8cs0d+mTzVKuPfqPKPatxLApaBoxJQ9x1/uckXtrS/U5oisPMDkNs0yQTaBRg==}
@@ -5588,6 +5663,7 @@ packages:
   nanoid@3.3.7:
     resolution: {integrity: sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
 
   native-fetch@3.0.0:
     resolution: {integrity: sha512-G3Z7vx0IFb/FQ4JxvtqGABsOTIqRWvgQz6e+erkB+JJD6LrszQtMozEHI4EkmgZQvnGHrpLVzUWk7t4sJCIkVw==}
@@ -5600,9 +5676,11 @@ packages:
   ndjson@2.0.0:
     resolution: {integrity: sha512-nGl7LRGrzugTtaFcJMhLbpzJM6XdivmbkdlaGcrk/LXg2KL/YBC6z1g70xh0/al+oFuVFP8N8kiWRucmeEH/qQ==}
     engines: {node: '>=10'}
+    hasBin: true
 
   nearley@2.20.1:
     resolution: {integrity: sha512-+Mc8UaAebFzgV+KpI5n7DasuuQCHA89dmwm7JXw3TV43ukfNQ9DnBH3Mdb2g/I4Fdxc26pwimBWvjIw0UAILSQ==}
+    hasBin: true
 
   negotiator@0.6.3:
     resolution: {integrity: sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==}
@@ -5657,6 +5735,7 @@ packages:
 
   node-gyp-build@4.7.1:
     resolution: {integrity: sha512-wTSrZ+8lsRRa3I3H8Xr65dLWSgCvY2l4AOnaeKdPA9TB/WYMPaTcrzf3rXvFoVvjKNVnu0CcWSx54qq9GKRUYg==}
+    hasBin: true
 
   node-int64@0.4.0:
     resolution: {integrity: sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==}
@@ -5671,6 +5750,7 @@ packages:
   nodemon@3.0.3:
     resolution: {integrity: sha512-7jH/NXbFPxVaMwmBCC2B9F/V6X1VkEdNgx3iu9jji8WxWcvhMWkmhNWhI5077zknOnZnBzba9hZP6bCPJLSReQ==}
     engines: {node: '>=10'}
+    hasBin: true
 
   nofilter@3.1.0:
     resolution: {integrity: sha512-l2NNj07e9afPnhAhvgVrCD/oy2Ai1yfLpuo3EpiO1jFTsB4sFz6oIfAfSZyQzVpkZQ9xS8ZS5g1jCBgq4Hwo0g==}
@@ -5678,6 +5758,7 @@ packages:
 
   nopt@1.0.10:
     resolution: {integrity: sha512-NWmpvLSqUrgrAC9HCuxEvb+PSloHpqVu+FqcO4eeF2h5qYRhA7ev6KvelyQAKtegUbC6RypJnlEOhd8vloNKYg==}
+    hasBin: true
 
   normalize-path@2.1.1:
     resolution: {integrity: sha512-3pKJwH184Xo/lnH6oyP1q2pMd7HcypqqmRs91/6/i2CGtWwIKGCkOOMTm/zXbgTEWHw1uNpNi/igc3ePOYHb6w==}
@@ -5717,6 +5798,7 @@ packages:
   nypm@0.3.8:
     resolution: {integrity: sha512-IGWlC6So2xv6V4cIDmoV0SwwWx7zLG086gyqkyumteH2fIgCAM4nDVFB2iDRszDvmdSVW9xb1N+2KjQ6C7d4og==}
     engines: {node: ^14.16.0 || >=16.10.0}
+    hasBin: true
 
   object-assign@4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
@@ -6028,6 +6110,7 @@ packages:
   pidtree@0.6.0:
     resolution: {integrity: sha512-eG2dWTVw5bzqGRztnHExczNxt5VGsE6OwTeCG3fdUf9KBsZzO3R5OIIIzWR+iZA0NtZ+RDVdaoE2dK1cn6jH4g==}
     engines: {node: '>=0.10'}
+    hasBin: true
 
   pify@2.3.0:
     resolution: {integrity: sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==}
@@ -6104,6 +6187,7 @@ packages:
   prettier@3.3.2:
     resolution: {integrity: sha512-rAVeHYMcv8ATV5d508CFdn+8/pHPpXeIid1DdrPwXnaAdH7cqjVbpJaT5eq4yRAFU/lsbwYwSF/n5iNrdJHPQA==}
     engines: {node: '>=14'}
+    hasBin: true
 
   pretty-format@29.7.0:
     resolution: {integrity: sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==}
@@ -6288,6 +6372,7 @@ packages:
 
   resolve@1.22.8:
     resolution: {integrity: sha512-oKWePCxqpd6FlLvGV1VU0x7bkPmmCNolxzjMf4NczoDnQcIWrAF+cPtZn5i6n+RfD2d9i0tzpKnG6Yk168yIyw==}
+    hasBin: true
 
   responselike@2.0.1:
     resolution: {integrity: sha512-4gl03wn3hj1HP3yzgdI7d3lCkF95F21Pz4BPGvKHinyQzALR5CapwC8yIi0Rh58DEMQ/SguC03wFj2k0M/mHhw==}
@@ -6328,16 +6413,19 @@ packages:
 
   rimraf@3.0.2:
     resolution: {integrity: sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==}
+    hasBin: true
 
   rimraf@5.0.5:
     resolution: {integrity: sha512-CqDakW+hMe/Bz202FPEymy68P+G50RfMQK+Qo5YUqc9SPipvbGjCGKd0RSKEelbsfQuw3g5NZDSrlZZAJurH1A==}
     engines: {node: '>=14'}
+    hasBin: true
 
   ripemd160@2.0.2:
     resolution: {integrity: sha512-ii4iagi25WusVoiC4B4lq7pbXfAp3D9v5CwfkY33vffw2+pkDjY1D8GaN7spsxvCSx8dkPqOZCEZyfxcmJG2IA==}
 
   rlp@2.2.7:
     resolution: {integrity: sha512-d5gdPmgQ0Z+AklL2NVXr/IoSjNZFfTVvQWzL/AM2AOcSzYP2xjlb0AC8YyCLc41MSNf6P6QVtjgPdmVtzb+4lQ==}
+    hasBin: true
 
   rollup-plugin-swc3@0.11.2:
     resolution: {integrity: sha512-o1ih9B806fV2wBSNk46T0cYfTF2eiiKmYXRpWw3K4j/Cp3tCAt10UCVsTqvUhGP58pcB3/GZcAVl5e7TCSKN6Q==}
@@ -6354,6 +6442,7 @@ packages:
   rollup@4.12.0:
     resolution: {integrity: sha512-wz66wn4t1OHIJw3+XU7mJJQV/2NAfw5OAk6G6Hoo3zcvz/XOfQ52Vgi+AN4Uxoxi0KBBwk2g8zPrTDA4btSB/Q==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
+    hasBin: true
 
   run-async@2.4.1:
     resolution: {integrity: sha512-tvVnVv01b8c1RrA6Ep7JkStj85Guv/YrMcwqYQnwjsAS2cTmmPGBBjAjpCW7RrSodNSoE2/qg9O4bceNvUuDgQ==}
@@ -6405,14 +6494,22 @@ packages:
 
   semver@6.3.1:
     resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
+    hasBin: true
 
   semver@7.5.4:
     resolution: {integrity: sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==}
     engines: {node: '>=10'}
+    hasBin: true
 
   semver@7.6.0:
     resolution: {integrity: sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==}
     engines: {node: '>=10'}
+    hasBin: true
+
+  semver@7.6.3:
+    resolution: {integrity: sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==}
+    engines: {node: '>=10'}
+    hasBin: true
 
   send@0.18.0:
     resolution: {integrity: sha512-qqWzuOjSFOuqPjFe4NOsMLafToQQwBSOEpS+FwEt3A2V3vKubTquT3vmLTQpFgMXp8AlFWFuP1qKaJZOtPpVXg==}
@@ -6447,6 +6544,7 @@ packages:
 
   sha.js@2.4.11:
     resolution: {integrity: sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==}
+    hasBin: true
 
   shebang-command@1.2.0:
     resolution: {integrity: sha512-EV3L1+UQWGor21OmnvojK36mhg+TyIKDh3iFBKBohr5xeXIhNBcx8oWdgkTEEQ+BEFFYdLRuqMfd5L84N1V5Vg==}
@@ -6687,6 +6785,7 @@ packages:
   supabase@1.191.3:
     resolution: {integrity: sha512-5tIG7mPc5lZ9QRbkZssyHiOsx42qGFaVqclauXv+1fJAkZnfA28d0pzEDvfs33+w8YTReO5nNaWAgyzkWQQwfA==}
     engines: {npm: '>=8'}
+    hasBin: true
 
   supports-color@5.5.0:
     resolution: {integrity: sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==}
@@ -6816,12 +6915,14 @@ packages:
 
   touch@3.1.0:
     resolution: {integrity: sha512-WBx8Uy5TLtOSRtIq+M03/sKDrXCLHxwDcquSP2c43Le03/9serjQBIztjRz6FkJez9D/hleyAXTBGLwwZUw9lA==}
+    hasBin: true
 
   tr46@0.0.3:
     resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
 
   tree-kill@1.2.2:
     resolution: {integrity: sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==}
+    hasBin: true
 
   treeify@1.1.0:
     resolution: {integrity: sha512-1m4RA7xVAJrSGrrXGs0L3YTwyvBs2S8PbRHaLZAkFw7JR8oIFwYtysxlBZhYIa7xSyiYJKZ3iGrrk55cGA3i9A==}
@@ -6852,6 +6953,7 @@ packages:
 
   ts-node@10.9.2:
     resolution: {integrity: sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==}
+    hasBin: true
     peerDependencies:
       '@swc/core': '>=1.2.50'
       '@swc/wasm': '>=1.2.50'
@@ -6883,6 +6985,7 @@ packages:
   tsoa@6.2.1:
     resolution: {integrity: sha512-cK+Wmw99IdkVMuNPl8OM+SufIxvS1b5XY9mwjLrTJ4ytwiUkF1AOKvF6pX5k/xDnHXFLCrfHzbgaogj0JJO9EA==}
     engines: {node: '>=18.0.0', yarn: '>=1.9.4'}
+    hasBin: true
 
   tsort@0.0.1:
     resolution: {integrity: sha512-Tyrf5mxF8Ofs1tNoxA13lFeZ2Zrbd6cKbuH3V+MQ5sb6DtBj5FjrXVsRWT8YvNAQTqNoz66dz1WsbigI22aEnw==}
@@ -6890,6 +6993,7 @@ packages:
   tsx@4.7.1:
     resolution: {integrity: sha512-8d6VuibXHtlN5E3zFkgY8u4DX7Y3Z27zvvPKVmLon/D4AjuKzarkUBTLDBgj9iTQ0hg5xM7c/mYiRVM+HETf0g==}
     engines: {node: '>=18.0.0'}
+    hasBin: true
 
   tsyringe@4.8.0:
     resolution: {integrity: sha512-YB1FG+axdxADa3ncEtRnQCFq/M0lALGLxSZeVNbTU8NqhOVc51nnv2CISTcvc1kyv6EGPtXVr0v6lWeDxiijOA==}
@@ -6967,6 +7071,7 @@ packages:
   typedoc@0.26.5:
     resolution: {integrity: sha512-Vn9YKdjKtDZqSk+by7beZ+xzkkr8T8CYoiasqyt4TTRFy5+UHzL/mF/o4wGBjRF+rlWQHDb0t6xCpA3JNL5phg==}
     engines: {node: '>= 18'}
+    hasBin: true
     peerDependencies:
       typescript: 4.6.x || 4.7.x || 4.8.x || 4.9.x || 5.0.x || 5.1.x || 5.2.x || 5.3.x || 5.4.x || 5.5.x
 
@@ -6983,10 +7088,12 @@ packages:
   typescript@5.5.3:
     resolution: {integrity: sha512-/hreyEujaB0w76zKo6717l3L0o/qEUtRgdvUBvlkhoWeOVMjMuHNHk0BRBzikzuGDqNmPQbg5ifMEqsHLiIUcQ==}
     engines: {node: '>=14.17'}
+    hasBin: true
 
   typescript@5.5.4:
     resolution: {integrity: sha512-Mtq29sKDAEYP7aljRgtPOpTvOfbwRWlS6dPRzwjdE+C0R4brX/GUyhHSecbHMFLNBLcJIPt9nl9yG5TZ1weH+Q==}
     engines: {node: '>=14.17'}
+    hasBin: true
 
   ua-parser-js@1.0.37:
     resolution: {integrity: sha512-bhTyI94tZofjo+Dn8SN6Zv8nBDvyXTymAdM3LDI/0IboIUwTu1rEhW7v2TfiVsoYWgkQ4kOVqnI8APUFbIQIFQ==}
@@ -7003,6 +7110,7 @@ packages:
   uglify-js@3.17.4:
     resolution: {integrity: sha512-T9q82TJI9e/C1TAxYvfb16xO120tMVFZrGA3f9/P4424DNu6ypK103y0GPFVa17yotwSyZW5iYXgjYHkGrJW/g==}
     engines: {node: '>=0.8.0'}
+    hasBin: true
 
   uint8arraylist@2.4.8:
     resolution: {integrity: sha512-vc1PlGOzglLF0eae1M8mLRTBivsvrGsdmJ5RbK3e+QRvRLOZfZhQROTwH/OfyF3+ZVUg9/8hE8bmKP2CvP9quQ==}
@@ -7065,6 +7173,7 @@ packages:
 
   update-browserslist-db@1.0.13:
     resolution: {integrity: sha512-xebP81SNcPuNpPP3uzeW1NYXxI3rxyJzF3pD6sH4jE7o/IX+WtSpwnVU+qIsDPyk0d3hmFQ7mjqc6AtV604hbg==}
+    hasBin: true
     peerDependencies:
       browserslist: '>= 4.21.0'
 
@@ -7098,12 +7207,14 @@ packages:
 
   uuid@3.4.0:
     resolution: {integrity: sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==}
+    hasBin: true
 
   uuid@8.3.2:
     resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
 
   uuid@9.0.1:
     resolution: {integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==}
+    hasBin: true
 
   v8-compile-cache-lib@3.0.1:
     resolution: {integrity: sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==}
@@ -7146,13 +7257,23 @@ packages:
       typescript:
         optional: true
 
+  viem@2.21.51:
+    resolution: {integrity: sha512-IBZTFoo9cZvMBkFqaJq5G8Ori4IeEDe9AHE5CmOlvNw7ytkC3vdVrJ/APL+V3H4d/5i1FiV331UsckIqQLIM0w==}
+    peerDependencies:
+      typescript: '>=5.0.4'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
   vite-node@1.1.3:
     resolution: {integrity: sha512-BLSO72YAkIUuNrOx+8uznYICJfTEbvBAmWClY3hpath5+h1mbPS5OMn42lrTxXuyCazVyZoDkSRnju78GiVCqA==}
     engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
 
   vite@5.0.11:
     resolution: {integrity: sha512-XBMnDjZcNAw/G1gEiskiM1v6yzM4GE5aMGvhWTlHAYYhxb7S3/V1s3m2LDHa8Vh6yIWYYB0iJwsEaS523c4oYA==}
     engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
     peerDependencies:
       '@types/node': ^18.0.0 || >=20.0.0
       less: '*'
@@ -7180,6 +7301,7 @@ packages:
   vitest@1.1.3:
     resolution: {integrity: sha512-2l8om1NOkiA90/Y207PsEvJLYygddsOyr81wLQ20Ra8IlLKbyQncWsGZjnbkyG2KwwuTXLQjEPOJuxGMG8qJBQ==}
     engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
     peerDependencies:
       '@edge-runtime/vm': '*'
       '@types/node': ^18.0.0 || >=20.0.0
@@ -7239,14 +7361,17 @@ packages:
 
   which@1.3.1:
     resolution: {integrity: sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==}
+    hasBin: true
 
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
     engines: {node: '>= 8'}
+    hasBin: true
 
   why-is-node-running@2.2.2:
     resolution: {integrity: sha512-6tSwToZxTOcotxHeA+qGCq1mVzKR3CwcJGmVcY+QE8SHy6TnpFnh8PAvPNHYr7EcuVeG0QSMxtYCuO1ta/G/oA==}
     engines: {node: '>=8'}
+    hasBin: true
 
   widest-line@3.1.0:
     resolution: {integrity: sha512-NsmoXalsWVDMGupxZ5R08ka9flZjjiLvHVAWYOKtiKM8ujtZWr9cRffak+uSE48+Ob8ObalXpwyeUiyDD6QFgg==}
@@ -7402,10 +7527,12 @@ packages:
   yaml@2.4.1:
     resolution: {integrity: sha512-pIXzoImaqmfOrL7teGUBt/T7ZDnyeGBWyXQBvOVhLkWLN37GXv8NMLK406UY6dS51JfcQHsmcW5cJ441bHg6Lg==}
     engines: {node: '>= 14'}
+    hasBin: true
 
   yaml@2.5.0:
     resolution: {integrity: sha512-2wWLbGbYDiSqqIKoPjar3MPgB94ErzCtrNE1FdqGuaO0pi2JGjmE8aW8TDZwzU7vuxcGRdL/4gPQwQ7hD5AMSw==}
     engines: {node: '>= 14'}
+    hasBin: true
 
   yargs-parser@18.1.3:
     resolution: {integrity: sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==}
@@ -7569,7 +7696,7 @@ snapshots:
       '@babel/traverse': 7.23.9
       '@babel/types': 7.23.9
       convert-source-map: 2.0.0
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@5.5.0)
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       semver: 6.3.1
@@ -7871,7 +7998,7 @@ snapshots:
       '@babel/helper-split-export-declaration': 7.22.6
       '@babel/parser': 7.24.7
       '@babel/types': 7.23.9
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@5.5.0)
       globals: 11.12.0
     transitivePeerDependencies:
       - supports-color
@@ -8121,7 +8248,7 @@ snapshots:
   '@eslint/eslintrc@2.1.4':
     dependencies:
       ajv: 6.12.6
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@5.5.0)
       espree: 9.6.1
       globals: 13.24.0
       ignore: 5.3.0
@@ -8866,7 +8993,7 @@ snapshots:
       '@types/json-stable-stringify': 1.0.36
       '@whatwg-node/fetch': 0.9.15
       chalk: 4.1.2
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@5.5.0)
       dotenv: 16.3.1
       graphql: 16.8.1
       graphql-request: 6.1.0(encoding@0.1.13)(graphql@16.8.1)
@@ -9188,7 +9315,7 @@ snapshots:
   '@humanwhocodes/config-array@0.11.13':
     dependencies:
       '@humanwhocodes/object-schema': 2.0.1
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@5.5.0)
       minimatch: 3.1.2
     transitivePeerDependencies:
       - supports-color
@@ -10153,6 +10280,47 @@ snapshots:
   '@rollup/rollup-win32-x64-msvc@4.12.0':
     optional: true
 
+  '@safe-global/api-kit@2.5.4(encoding@0.1.13)(typescript@5.5.3)(zod@3.23.8)':
+    dependencies:
+      '@safe-global/protocol-kit': 5.0.4(typescript@5.5.3)(zod@3.23.8)
+      '@safe-global/types-kit': 1.0.0(typescript@5.5.3)(zod@3.23.8)
+      node-fetch: 2.7.0(encoding@0.1.13)
+      viem: 2.21.51(typescript@5.5.3)(zod@3.23.8)
+    transitivePeerDependencies:
+      - bufferutil
+      - encoding
+      - typescript
+      - utf-8-validate
+      - zod
+
+  '@safe-global/protocol-kit@5.0.4(typescript@5.5.3)(zod@3.23.8)':
+    dependencies:
+      '@noble/hashes': 1.4.0
+      '@safe-global/safe-deployments': 1.37.18
+      '@safe-global/safe-modules-deployments': 2.2.4
+      '@safe-global/types-kit': 1.0.0(typescript@5.5.3)(zod@3.23.8)
+      abitype: 1.0.6(typescript@5.5.3)(zod@3.23.8)
+      semver: 7.6.3
+      viem: 2.21.51(typescript@5.5.3)(zod@3.23.8)
+    transitivePeerDependencies:
+      - bufferutil
+      - typescript
+      - utf-8-validate
+      - zod
+
+  '@safe-global/safe-deployments@1.37.18':
+    dependencies:
+      semver: 7.6.3
+
+  '@safe-global/safe-modules-deployments@2.2.4': {}
+
+  '@safe-global/types-kit@1.0.0(typescript@5.5.3)(zod@3.23.8)':
+    dependencies:
+      abitype: 1.0.6(typescript@5.5.3)(zod@3.23.8)
+    transitivePeerDependencies:
+      - typescript
+      - zod
+
   '@sagold/json-pointer@5.1.2': {}
 
   '@sagold/json-query@6.2.0':
@@ -10403,7 +10571,7 @@ snapshots:
       c12: 1.10.0
       change-case: 5.4.4
       ci-info: 4.0.0
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@5.5.0)
       dedent: 1.5.3
       deepmerge: 4.3.1
       execa: 8.0.1
@@ -10616,7 +10784,7 @@ snapshots:
       fs-extra: 10.1.0
       hardhat: 2.22.16(ts-node@10.9.2(@swc/core@1.4.15)(@types/node@20.10.6)(typescript@5.5.3))(typescript@5.5.3)
       hardhat-deploy: 0.11.45
-      tenderly: 0.9.1(ts-node@10.9.2(@swc/core@1.4.15)(@types/node@20.10.6)(typescript@5.5.4))(typescript@5.5.4)
+      tenderly: 0.9.1(ts-node@10.9.2(@swc/core@1.4.15)(@types/node@20.10.6)(typescript@5.5.3))(typescript@5.5.4)
       ts-node: 10.9.2(@swc/core@1.4.15)(@types/node@20.10.6)(typescript@5.5.4)
       tslog: 4.9.3
       typescript: 5.5.4
@@ -10643,7 +10811,7 @@ snapshots:
       fs-extra: 10.1.0
       hardhat: 2.22.16(ts-node@10.9.2(@swc/core@1.4.15)(@types/node@20.10.6)(typescript@5.5.3))(typescript@5.5.3)
       hardhat-deploy: 0.11.45
-      tenderly: 0.9.1(ts-node@10.9.2(@swc/core@1.6.5)(@types/node@20.10.6)(typescript@5.5.4))(typescript@5.5.4)
+      tenderly: 0.9.1(ts-node@10.9.2(@swc/core@1.4.15)(@types/node@20.10.6)(typescript@5.5.3))(typescript@5.5.4)
       ts-node: 10.9.2(@swc/core@1.6.5)(@types/node@20.10.6)(typescript@5.5.4)
       tslog: 4.9.3
       typescript: 5.5.4
@@ -10941,7 +11109,7 @@ snapshots:
       '@typescript-eslint/type-utils': 7.7.0(eslint@8.56.0)(typescript@5.5.3)
       '@typescript-eslint/utils': 7.7.0(eslint@8.56.0)(typescript@5.5.3)
       '@typescript-eslint/visitor-keys': 7.7.0
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@5.5.0)
       eslint: 8.56.0
       graphemer: 1.4.0
       ignore: 5.3.1
@@ -10959,7 +11127,7 @@ snapshots:
       '@typescript-eslint/types': 7.7.0
       '@typescript-eslint/typescript-estree': 7.7.0(typescript@5.5.3)
       '@typescript-eslint/visitor-keys': 7.7.0
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@5.5.0)
       eslint: 8.56.0
     optionalDependencies:
       typescript: 5.5.3
@@ -10975,7 +11143,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/typescript-estree': 7.7.0(typescript@5.5.3)
       '@typescript-eslint/utils': 7.7.0(eslint@8.56.0)(typescript@5.5.3)
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@5.5.0)
       eslint: 8.56.0
       ts-api-utils: 1.3.0(typescript@5.5.3)
     optionalDependencies:
@@ -10989,7 +11157,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/types': 7.7.0
       '@typescript-eslint/visitor-keys': 7.7.0
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@5.5.0)
       globby: 11.1.0
       is-glob: 4.0.3
       minimatch: 9.0.4
@@ -11336,6 +11504,11 @@ snapshots:
       typescript: 5.5.3
       zod: 3.23.8
 
+  abitype@1.0.6(typescript@5.5.3)(zod@3.23.8):
+    optionalDependencies:
+      typescript: 5.5.3
+      zod: 3.23.8
+
   abort-controller@3.0.0:
     dependencies:
       event-target-shim: 5.0.1
@@ -11377,7 +11550,7 @@ snapshots:
 
   agent-base@7.1.0:
     dependencies:
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -12618,7 +12791,7 @@ snapshots:
       ajv: 6.12.6
       chalk: 4.1.2
       cross-spawn: 7.0.3
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@5.5.0)
       doctrine: 3.0.0
       escape-string-regexp: 4.0.0
       eslint-scope: 7.2.2
@@ -13044,7 +13217,7 @@ snapshots:
 
   follow-redirects@1.15.4(debug@4.3.4):
     optionalDependencies:
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@5.5.0)
 
   follow-redirects@1.15.6(debug@4.3.6):
     optionalDependencies:
@@ -13518,7 +13691,7 @@ snapshots:
   http-proxy-agent@7.0.2:
     dependencies:
       agent-base: 7.1.0
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -13537,7 +13710,7 @@ snapshots:
   https-proxy-agent@7.0.4:
     dependencies:
       agent-base: 7.1.0
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -13848,6 +14021,10 @@ snapshots:
   isows@1.0.3(ws@8.13.0):
     dependencies:
       ws: 8.13.0
+
+  isows@1.0.6(ws@8.18.0):
+    dependencies:
+      ws: 8.18.0
 
   isows@1.0.6(ws@8.18.0):
     dependencies:
@@ -15117,7 +15294,7 @@ snapshots:
 
   require-in-the-middle@7.3.0:
     dependencies:
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@5.5.0)
       module-details-from-path: 1.0.3
       resolve: 1.22.8
     transitivePeerDependencies:
@@ -15280,6 +15457,8 @@ snapshots:
   semver@7.6.0:
     dependencies:
       lru-cache: 6.0.0
+
+  semver@7.6.3: {}
 
   send@0.18.0:
     dependencies:
@@ -15672,7 +15851,7 @@ snapshots:
       mkdirp: 3.0.1
       yallist: 5.0.0
 
-  tenderly@0.9.1(ts-node@10.9.2(@swc/core@1.4.15)(@types/node@20.10.6)(typescript@5.5.4))(typescript@5.5.4):
+  tenderly@0.9.1(ts-node@10.9.2(@swc/core@1.4.15)(@types/node@20.10.6)(typescript@5.5.3))(typescript@5.5.4):
     dependencies:
       axios: 0.27.2
       cli-table3: 0.6.5
@@ -15682,22 +15861,7 @@ snapshots:
       prompts: 2.4.2
       tslog: 4.9.3
     optionalDependencies:
-      ts-node: 10.9.2(@swc/core@1.4.15)(@types/node@20.10.6)(typescript@5.5.4)
-      typescript: 5.5.4
-    transitivePeerDependencies:
-      - debug
-
-  tenderly@0.9.1(ts-node@10.9.2(@swc/core@1.6.5)(@types/node@20.10.6)(typescript@5.5.4))(typescript@5.5.4):
-    dependencies:
-      axios: 0.27.2
-      cli-table3: 0.6.5
-      commander: 9.5.0
-      js-yaml: 4.1.0
-      open: 8.4.2
-      prompts: 2.4.2
-      tslog: 4.9.3
-    optionalDependencies:
-      ts-node: 10.9.2(@swc/core@1.6.5)(@types/node@20.10.6)(typescript@5.5.4)
+      ts-node: 10.9.2(@swc/core@1.4.15)(@types/node@20.10.6)(typescript@5.5.3)
       typescript: 5.5.4
     transitivePeerDependencies:
       - debug
@@ -16121,10 +16285,28 @@ snapshots:
       - utf-8-validate
       - zod
 
+  viem@2.21.51(typescript@5.5.3)(zod@3.23.8):
+    dependencies:
+      '@noble/curves': 1.6.0
+      '@noble/hashes': 1.5.0
+      '@scure/bip32': 1.5.0
+      '@scure/bip39': 1.4.0
+      abitype: 1.0.6(typescript@5.5.3)(zod@3.23.8)
+      isows: 1.0.6(ws@8.18.0)
+      ox: 0.1.2(typescript@5.5.3)(zod@3.23.8)
+      webauthn-p256: 0.0.10
+      ws: 8.18.0
+    optionalDependencies:
+      typescript: 5.5.3
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+      - zod
+
   vite-node@1.1.3(@types/node@20.10.6):
     dependencies:
       cac: 6.7.14
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@5.5.0)
       pathe: 1.1.1
       picocolors: 1.0.0
       vite: 5.0.11(@types/node@20.10.6)
@@ -16157,7 +16339,7 @@ snapshots:
       acorn-walk: 8.3.1
       cac: 6.7.14
       chai: 4.4.0
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@5.5.0)
       execa: 8.0.1
       local-pkg: 0.5.0
       magic-string: 0.30.5

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,13 +16,13 @@ importers:
         version: 3.5.0(@envelop/core@5.0.0)(graphql-yoga@5.1.1(graphql@16.8.1))(graphql@16.8.1)
       '@hypercerts-org/contracts':
         specifier: 2.0.0-alpha.11
-        version: 2.0.0-alpha.11(@nomicfoundation/hardhat-ethers@3.0.6(ethers@6.12.2)(hardhat@2.22.16(ts-node@10.9.2(@swc/core@1.4.15)(@types/node@20.10.6)(typescript@5.5.3))(typescript@5.5.3)))(@swc/core@1.4.15)(@types/node@20.10.6)(encoding@0.1.13)(ethers@6.12.2)(ts-node@10.9.2(@swc/core@1.4.15)(@types/node@20.10.6)(typescript@5.5.3))(typescript@5.5.3)
+        version: 2.0.0-alpha.11(@nomicfoundation/hardhat-ethers@3.0.6(ethers@6.12.2)(hardhat@2.22.17(ts-node@10.9.2(@swc/core@1.4.15)(@types/node@20.10.6)(typescript@5.5.3))(typescript@5.5.3)))(@swc/core@1.4.15)(@types/node@20.10.6)(encoding@0.1.13)(ethers@6.12.2)(ts-node@10.9.2(@swc/core@1.4.15)(@types/node@20.10.6)(typescript@5.5.3))(typescript@5.5.3)
       '@hypercerts-org/marketplace-sdk':
         specifier: 0.3.37
-        version: 0.3.37(@nomicfoundation/hardhat-ethers@3.0.6(ethers@6.12.2)(hardhat@2.22.16(ts-node@10.9.2(@swc/core@1.4.15)(@types/node@20.10.6)(typescript@5.5.3))(typescript@5.5.3)))(@types/node@20.10.6)(encoding@0.1.13)(ethers@6.12.2)(graphql@16.8.1)(rollup@4.12.0)(svelte@4.2.18)(ts-node@10.9.2(@swc/core@1.4.15)(@types/node@20.10.6)(typescript@5.5.3))(typescript@5.5.3)
+        version: 0.3.37(@nomicfoundation/hardhat-ethers@3.0.6(ethers@6.12.2)(hardhat@2.22.17(ts-node@10.9.2(@swc/core@1.4.15)(@types/node@20.10.6)(typescript@5.5.3))(typescript@5.5.3)))(@types/node@20.10.6)(encoding@0.1.13)(ethers@6.12.2)(graphql@16.8.1)(rollup@4.12.0)(svelte@4.2.18)(ts-node@10.9.2(@swc/core@1.4.15)(@types/node@20.10.6)(typescript@5.5.3))(typescript@5.5.3)
       '@hypercerts-org/sdk':
         specifier: 2.3.0
-        version: 2.3.0(@nomicfoundation/hardhat-ethers@3.0.6(ethers@6.12.2)(hardhat@2.22.16(ts-node@10.9.2(@swc/core@1.4.15)(@types/node@20.10.6)(typescript@5.5.3))(typescript@5.5.3)))(@types/node@20.10.6)(encoding@0.1.13)(ethers@6.12.2)(graphql@16.8.1)(rollup@4.12.0)(ts-node@10.9.2(@swc/core@1.4.15)(@types/node@20.10.6)(typescript@5.5.3))(typescript@5.5.3)
+        version: 2.3.0(@nomicfoundation/hardhat-ethers@3.0.6(ethers@6.12.2)(hardhat@2.22.17(ts-node@10.9.2(@swc/core@1.4.15)(@types/node@20.10.6)(typescript@5.5.3))(typescript@5.5.3)))(@types/node@20.10.6)(encoding@0.1.13)(ethers@6.12.2)(graphql@16.8.1)(rollup@4.12.0)(ts-node@10.9.2(@swc/core@1.4.15)(@types/node@20.10.6)(typescript@5.5.3))(typescript@5.5.3)
       '@ipld/car':
         specifier: ^5.2.5
         version: 5.2.5
@@ -32,6 +32,9 @@ importers:
       '@safe-global/api-kit':
         specifier: ^2.5.4
         version: 2.5.4(encoding@0.1.13)(typescript@5.5.3)(zod@3.23.8)
+      '@safe-global/protocol-kit':
+        specifier: ^5.0.4
+        version: 5.0.4(typescript@5.5.3)(zod@3.23.8)
       '@sentry/integrations':
         specifier: ^7.114.0
         version: 7.114.0
@@ -191,7 +194,7 @@ importers:
         version: 8.2.1
       '@swc/cli':
         specifier: ^0.3.12
-        version: 0.3.12(@swc/core@1.4.15)(chokidar@4.0.1)
+        version: 0.3.12(@swc/core@1.4.15)(chokidar@3.6.0)
       '@swc/core':
         specifier: ^1.4.15
         version: 1.4.15
@@ -1651,6 +1654,7 @@ packages:
   '@nomicfoundation/ethereumjs-rlp@5.0.4':
     resolution: {integrity: sha512-8H1S3s8F6QueOc/X92SdrA4RDenpiAEqMg5vJH99kcQaCy/a3Q6fgseo75mgWlbanGJXSlAPtnCeG9jvfTYXlw==}
     engines: {node: '>=18'}
+    hasBin: true
 
   '@nomicfoundation/ethereumjs-tx@5.0.4':
     resolution: {integrity: sha512-Xjv8wAKJGMrP1f0n2PeyfFCCojHd7iS3s/Ab7qzF1S64kxZ8Z22LCMynArYsVqiFx6rzYy548HNVEyI+AYN/kw==}
@@ -3010,17 +3014,6 @@ packages:
       zod:
         optional: true
 
-  abitype@1.0.6:
-    resolution: {integrity: sha512-MMSqYh4+C/aVqI2RQaWqbvI4Kxo5cQV40WQ4QFtDnNzCkqChm8MuENhElmynZlO0qUy/ObkEUaXtKqYnx1Kp3A==}
-    peerDependencies:
-      typescript: '>=5.0.4'
-      zod: ^3 >=3.22.0
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-      zod:
-        optional: true
-
   abort-controller@3.0.0:
     resolution: {integrity: sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==}
     engines: {node: '>=6.5'}
@@ -3258,8 +3251,8 @@ packages:
   axios@1.7.2:
     resolution: {integrity: sha512-2A8QhOMrbomlDuiLeK9XibIBzuHeRcqqNOHp0Cyp5EoJ1IFDh+XZH3A6BkXtv0K4gFGCI0Y4BM7B1wOEi0Rmgw==}
 
-  axios@1.7.7:
-    resolution: {integrity: sha512-S4kL7XrjgBmvdGut0sN3yJxqYzrDOnivkBiN0OFs6hLiUam3UPvswUo0kqGyhqUZGEOytHyumEdXsAkgCOUf3Q==}
+  axios@1.7.9:
+    resolution: {integrity: sha512-LhLcE7Hbiryz8oMDdDptSrWowmB4Bl6RCt6sIJKpRB4XtVf0iEgewX3au/pJqm+Py1kCASkb/FFKjxQaLtxJvw==}
 
   axobject-query@4.1.0:
     resolution: {integrity: sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==}
@@ -4197,6 +4190,7 @@ packages:
 
   ethereumjs-abi@0.6.8:
     resolution: {integrity: sha512-Tx0r/iXI6r+lRsdvkFDlut0N08jWMnKRZ6Gkq+Nmw75lZe4e6o3EkSnkaBP5NF6+m5PTGAr9JP43N3LyeoglsA==}
+    deprecated: This library has been deprecated and usage is discouraged.
 
   ethereumjs-util@6.2.1:
     resolution: {integrity: sha512-W2Ktez4L01Vexijrm5EB6w7dg4n/TgpoYU4avuT5T3Vmnw/eCRtiBrJfQYS/DCSvDIOLn2k57GcHdeBcgVxAqw==}
@@ -4386,6 +4380,7 @@ packages:
 
   flat@5.0.2:
     resolution: {integrity: sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==}
+    hasBin: true
 
   flatted@3.2.9:
     resolution: {integrity: sha512-36yxDn5H7OFZQla0/jFJmbIKTdZAQHngCedGxiMmpNfEZM0sdEeT+WczLQrjK6D7o2aiyLYDnkw0R3JK0Qv1RQ==}
@@ -4550,6 +4545,7 @@ packages:
 
   glob@7.2.0:
     resolution: {integrity: sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==}
+    deprecated: Glob versions prior to v9 are no longer supported
 
   glob@7.2.3:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
@@ -4667,8 +4663,9 @@ packages:
   hardhat-deploy@0.11.45:
     resolution: {integrity: sha512-aC8UNaq3JcORnEUIwV945iJuvBwi65tjHVDU3v6mOcqik7WAzHVCJ7cwmkkipsHrWysrB5YvGF1q9S1vIph83w==}
 
-  hardhat@2.22.16:
-    resolution: {integrity: sha512-d52yQZ09u0roL6GlgJSvtknsBtIuj9JrJ/U8VMzr/wue+gO5v2tQayvOX6llerlR57Zw2EOTQjLAt6RpHvjwHA==}
+  hardhat@2.22.17:
+    resolution: {integrity: sha512-tDlI475ccz4d/dajnADUTRc1OJ3H8fpP9sWhXhBPpYsQOg8JHq5xrDimo53UhWPl7KJmAeDCm1bFG74xvpGRpg==}
+    hasBin: true
     peerDependencies:
       ts-node: '*'
       typescript: '*'
@@ -5082,11 +5079,6 @@ packages:
 
   isows@1.0.3:
     resolution: {integrity: sha512-2cKei4vlmg2cxEjm3wVSqn8pcoRF/LX/wpifuuNquFO4SQmPwarClT+SUCA2lt+l581tTeZIPIZuIDo2jWN1fg==}
-    peerDependencies:
-      ws: '*'
-
-  isows@1.0.6:
-    resolution: {integrity: sha512-lPHCayd40oW98/I0uvgaHKWCSvkzY27LjWLbtzOm64yQ+G3Q5npjjbdppU65iZXkK1Zt+kH9pfegli0AYfwYYw==}
     peerDependencies:
       ws: '*'
 
@@ -5605,6 +5597,7 @@ packages:
   mocha@10.2.0:
     resolution: {integrity: sha512-IDY7fl/BecMwFHzoqF2sg/SHHANeBoMMXFlS9r0OXKDssYE1M5O43wUY/9BVPeIvfH2zmEbBfseqN9gBQZzXkg==}
     engines: {node: '>= 14.0.0'}
+    hasBin: true
 
   module-details-from-path@1.0.3:
     resolution: {integrity: sha512-ySViT69/76t8VhE1xXHK6Ch4NcDd26gx0MzKXLO+F7NOtnqH68d9zF94nT8ZWSxXh8ELOERsnJO/sWt1xZYw5A==}
@@ -5659,6 +5652,7 @@ packages:
   nanoid@3.3.3:
     resolution: {integrity: sha512-p1sjXuopFs0xg+fPASzQ28agW1oHD7xDsd9Xkf3T15H3c/cifrFHVwrh74PdoklAPi+i7MdRsE47vm2r6JoB+w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
 
   nanoid@3.3.7:
     resolution: {integrity: sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==}
@@ -6491,6 +6485,7 @@ packages:
 
   semver@5.7.2:
     resolution: {integrity: sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==}
+    hasBin: true
 
   semver@6.3.1:
     resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
@@ -6630,6 +6625,7 @@ packages:
   solc@0.8.26:
     resolution: {integrity: sha512-yiPQNVf5rBFHwN6SIf3TUUvVAFKcQqmSUFeq+fb6pNRCo0ZCgpYOZDi3BVoezCPIAcKrVYd/qXlBLUP9wVrZ9g==}
     engines: {node: '>=10.0.0'}
+    hasBin: true
 
   solidity-ast@0.4.56:
     resolution: {integrity: sha512-HgmsA/Gfklm/M8GFbCX/J1qkVH0spXHgALCNZ8fA8x5X+MFdn/8CP2gr5OVyXjXw6RZTPC/Sxl2RUDQOXyNMeA==}
@@ -7211,6 +7207,7 @@ packages:
 
   uuid@8.3.2:
     resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
+    hasBin: true
 
   uuid@9.0.1:
     resolution: {integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==}
@@ -7243,14 +7240,6 @@ packages:
 
   viem@2.0.3:
     resolution: {integrity: sha512-9r+CMEA0zf8QCvCobTUX4vhP9x0t7wRjHbadfHDHw8ULjnzwoQc1Yc1pK99GtqK4hv5hKacDe78dibg80p/a+A==}
-    peerDependencies:
-      typescript: '>=5.0.4'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-
-  viem@2.21.49:
-    resolution: {integrity: sha512-NNItYfTv4+yGE5DDKc+S/g2S7KeJn047GwgEYG60FAJlK0FzwuP6lQKSeQ8k7Y4VasfuKPqiT+XiilcCtTRiDQ==}
     peerDependencies:
       typescript: '>=5.0.4'
     peerDependenciesMeta:
@@ -7586,6 +7575,7 @@ packages:
 
   zksync-web3@0.14.4:
     resolution: {integrity: sha512-kYehMD/S6Uhe1g434UnaMN+sBr9nQm23Ywn0EUP5BfQCsbjcr3ORuS68PosZw8xUTu3pac7G6YMSnNHk+fwzvg==}
+    deprecated: This package has been deprecated in favor of zksync-ethers@5.0.0
     peerDependencies:
       ethers: ^5.7.0
 
@@ -9324,11 +9314,11 @@ snapshots:
 
   '@humanwhocodes/object-schema@2.0.1': {}
 
-  '@hypercerts-org/contracts@2.0.0-alpha.11(@nomicfoundation/hardhat-ethers@3.0.6(ethers@6.12.2)(hardhat@2.22.16(ts-node@10.9.2(@swc/core@1.4.15)(@types/node@20.10.6)(typescript@5.5.3))(typescript@5.5.3)))(@swc/core@1.4.15)(@types/node@20.10.6)(encoding@0.1.13)(ethers@6.12.2)(ts-node@10.9.2(@swc/core@1.4.15)(@types/node@20.10.6)(typescript@5.5.3))(typescript@5.5.3)':
+  '@hypercerts-org/contracts@2.0.0-alpha.11(@nomicfoundation/hardhat-ethers@3.0.6(ethers@6.12.2)(hardhat@2.22.17(ts-node@10.9.2(@swc/core@1.4.15)(@types/node@20.10.6)(typescript@5.5.3))(typescript@5.5.3)))(@swc/core@1.4.15)(@types/node@20.10.6)(encoding@0.1.13)(ethers@6.12.2)(ts-node@10.9.2(@swc/core@1.4.15)(@types/node@20.10.6)(typescript@5.5.3))(typescript@5.5.3)':
     dependencies:
-      '@starboardventures/hardhat-verify': 1.0.1(hardhat@2.22.16(ts-node@10.9.2(@swc/core@1.4.15)(@types/node@20.10.6)(typescript@5.5.3))(typescript@5.5.3))
-      '@tenderly/hardhat-tenderly': 2.3.0(@nomicfoundation/hardhat-ethers@3.0.6(ethers@6.12.2)(hardhat@2.22.16(ts-node@10.9.2(@swc/core@1.4.15)(@types/node@20.10.6)(typescript@5.5.3))(typescript@5.5.3)))(@swc/core@1.4.15)(@types/node@20.10.6)(encoding@0.1.13)(ethers@6.12.2)(hardhat@2.22.16(ts-node@10.9.2(@swc/core@1.4.15)(@types/node@20.10.6)(typescript@5.5.3))(typescript@5.5.3))
-      hardhat: 2.22.16(ts-node@10.9.2(@swc/core@1.4.15)(@types/node@20.10.6)(typescript@5.5.3))(typescript@5.5.3)
+      '@starboardventures/hardhat-verify': 1.0.1(hardhat@2.22.17(ts-node@10.9.2(@swc/core@1.4.15)(@types/node@20.10.6)(typescript@5.5.3))(typescript@5.5.3))
+      '@tenderly/hardhat-tenderly': 2.3.0(@nomicfoundation/hardhat-ethers@3.0.6(ethers@6.12.2)(hardhat@2.22.17(ts-node@10.9.2(@swc/core@1.4.15)(@types/node@20.10.6)(typescript@5.5.3))(typescript@5.5.3)))(@swc/core@1.4.15)(@types/node@20.10.6)(encoding@0.1.13)(ethers@6.12.2)(hardhat@2.22.17(ts-node@10.9.2(@swc/core@1.4.15)(@types/node@20.10.6)(typescript@5.5.3))(typescript@5.5.3))
+      hardhat: 2.22.17(ts-node@10.9.2(@swc/core@1.4.15)(@types/node@20.10.6)(typescript@5.5.3))(typescript@5.5.3)
     transitivePeerDependencies:
       - '@nomicfoundation/hardhat-ethers'
       - '@swc/core'
@@ -9344,11 +9334,11 @@ snapshots:
       - typescript
       - utf-8-validate
 
-  '@hypercerts-org/contracts@2.0.0-alpha.11(@nomicfoundation/hardhat-ethers@3.0.6(ethers@6.12.2)(hardhat@2.22.16(ts-node@10.9.2(@swc/core@1.4.15)(@types/node@20.10.6)(typescript@5.5.3))(typescript@5.5.3)))(@swc/core@1.6.5)(@types/node@20.10.6)(encoding@0.1.13)(ethers@6.12.2)(ts-node@10.9.2(@swc/core@1.4.15)(@types/node@20.10.6)(typescript@5.5.3))(typescript@5.5.3)':
+  '@hypercerts-org/contracts@2.0.0-alpha.11(@nomicfoundation/hardhat-ethers@3.0.6(ethers@6.12.2)(hardhat@2.22.17(ts-node@10.9.2(@swc/core@1.4.15)(@types/node@20.10.6)(typescript@5.5.3))(typescript@5.5.3)))(@swc/core@1.6.5)(@types/node@20.10.6)(encoding@0.1.13)(ethers@6.12.2)(ts-node@10.9.2(@swc/core@1.4.15)(@types/node@20.10.6)(typescript@5.5.3))(typescript@5.5.3)':
     dependencies:
-      '@starboardventures/hardhat-verify': 1.0.1(hardhat@2.22.16(ts-node@10.9.2(@swc/core@1.4.15)(@types/node@20.10.6)(typescript@5.5.3))(typescript@5.5.3))
-      '@tenderly/hardhat-tenderly': 2.3.0(@nomicfoundation/hardhat-ethers@3.0.6(ethers@6.12.2)(hardhat@2.22.16(ts-node@10.9.2(@swc/core@1.4.15)(@types/node@20.10.6)(typescript@5.5.3))(typescript@5.5.3)))(@swc/core@1.6.5)(@types/node@20.10.6)(encoding@0.1.13)(ethers@6.12.2)(hardhat@2.22.16(ts-node@10.9.2(@swc/core@1.4.15)(@types/node@20.10.6)(typescript@5.5.3))(typescript@5.5.3))
-      hardhat: 2.22.16(ts-node@10.9.2(@swc/core@1.4.15)(@types/node@20.10.6)(typescript@5.5.3))(typescript@5.5.3)
+      '@starboardventures/hardhat-verify': 1.0.1(hardhat@2.22.17(ts-node@10.9.2(@swc/core@1.4.15)(@types/node@20.10.6)(typescript@5.5.3))(typescript@5.5.3))
+      '@tenderly/hardhat-tenderly': 2.3.0(@nomicfoundation/hardhat-ethers@3.0.6(ethers@6.12.2)(hardhat@2.22.17(ts-node@10.9.2(@swc/core@1.4.15)(@types/node@20.10.6)(typescript@5.5.3))(typescript@5.5.3)))(@swc/core@1.6.5)(@types/node@20.10.6)(encoding@0.1.13)(ethers@6.12.2)(hardhat@2.22.17(ts-node@10.9.2(@swc/core@1.4.15)(@types/node@20.10.6)(typescript@5.5.3))(typescript@5.5.3))
+      hardhat: 2.22.17(ts-node@10.9.2(@swc/core@1.4.15)(@types/node@20.10.6)(typescript@5.5.3))(typescript@5.5.3)
     transitivePeerDependencies:
       - '@nomicfoundation/hardhat-ethers'
       - '@swc/core'
@@ -9364,9 +9354,9 @@ snapshots:
       - typescript
       - utf-8-validate
 
-  '@hypercerts-org/marketplace-sdk@0.3.37(@nomicfoundation/hardhat-ethers@3.0.6(ethers@6.12.2)(hardhat@2.22.16(ts-node@10.9.2(@swc/core@1.4.15)(@types/node@20.10.6)(typescript@5.5.3))(typescript@5.5.3)))(@types/node@20.10.6)(encoding@0.1.13)(ethers@6.12.2)(graphql@16.8.1)(rollup@4.12.0)(svelte@4.2.18)(ts-node@10.9.2(@swc/core@1.4.15)(@types/node@20.10.6)(typescript@5.5.3))(typescript@5.5.3)':
+  '@hypercerts-org/marketplace-sdk@0.3.37(@nomicfoundation/hardhat-ethers@3.0.6(ethers@6.12.2)(hardhat@2.22.17(ts-node@10.9.2(@swc/core@1.4.15)(@types/node@20.10.6)(typescript@5.5.3))(typescript@5.5.3)))(@types/node@20.10.6)(encoding@0.1.13)(ethers@6.12.2)(graphql@16.8.1)(rollup@4.12.0)(svelte@4.2.18)(ts-node@10.9.2(@swc/core@1.4.15)(@types/node@20.10.6)(typescript@5.5.3))(typescript@5.5.3)':
     dependencies:
-      '@hypercerts-org/sdk': 2.3.0(@nomicfoundation/hardhat-ethers@3.0.6(ethers@6.12.2)(hardhat@2.22.16(ts-node@10.9.2(@swc/core@1.4.15)(@types/node@20.10.6)(typescript@5.5.3))(typescript@5.5.3)))(@types/node@20.10.6)(encoding@0.1.13)(ethers@6.12.2)(graphql@16.8.1)(rollup@4.12.0)(ts-node@10.9.2(@swc/core@1.4.15)(@types/node@20.10.6)(typescript@5.5.3))(typescript@5.5.3)
+      '@hypercerts-org/sdk': 2.3.0(@nomicfoundation/hardhat-ethers@3.0.6(ethers@6.12.2)(hardhat@2.22.17(ts-node@10.9.2(@swc/core@1.4.15)(@types/node@20.10.6)(typescript@5.5.3))(typescript@5.5.3)))(@types/node@20.10.6)(encoding@0.1.13)(ethers@6.12.2)(graphql@16.8.1)(rollup@4.12.0)(ts-node@10.9.2(@swc/core@1.4.15)(@types/node@20.10.6)(typescript@5.5.3))(typescript@5.5.3)
       '@supabase/supabase-js': 2.42.5
       '@urql/core': 5.0.4(graphql@16.8.1)
       ethers: 6.12.2
@@ -9389,17 +9379,17 @@ snapshots:
       - typescript
       - utf-8-validate
 
-  '@hypercerts-org/sdk@2.3.0(@nomicfoundation/hardhat-ethers@3.0.6(ethers@6.12.2)(hardhat@2.22.16(ts-node@10.9.2(@swc/core@1.4.15)(@types/node@20.10.6)(typescript@5.5.3))(typescript@5.5.3)))(@types/node@20.10.6)(encoding@0.1.13)(ethers@6.12.2)(graphql@16.8.1)(rollup@4.12.0)(ts-node@10.9.2(@swc/core@1.4.15)(@types/node@20.10.6)(typescript@5.5.3))(typescript@5.5.3)':
+  '@hypercerts-org/sdk@2.3.0(@nomicfoundation/hardhat-ethers@3.0.6(ethers@6.12.2)(hardhat@2.22.17(ts-node@10.9.2(@swc/core@1.4.15)(@types/node@20.10.6)(typescript@5.5.3))(typescript@5.5.3)))(@types/node@20.10.6)(encoding@0.1.13)(ethers@6.12.2)(graphql@16.8.1)(rollup@4.12.0)(ts-node@10.9.2(@swc/core@1.4.15)(@types/node@20.10.6)(typescript@5.5.3))(typescript@5.5.3)':
     dependencies:
       '@graphql-typed-document-node/core': 3.2.0(graphql@16.8.1)
-      '@hypercerts-org/contracts': 2.0.0-alpha.11(@nomicfoundation/hardhat-ethers@3.0.6(ethers@6.12.2)(hardhat@2.22.16(ts-node@10.9.2(@swc/core@1.4.15)(@types/node@20.10.6)(typescript@5.5.3))(typescript@5.5.3)))(@swc/core@1.6.5)(@types/node@20.10.6)(encoding@0.1.13)(ethers@6.12.2)(ts-node@10.9.2(@swc/core@1.4.15)(@types/node@20.10.6)(typescript@5.5.3))(typescript@5.5.3)
+      '@hypercerts-org/contracts': 2.0.0-alpha.11(@nomicfoundation/hardhat-ethers@3.0.6(ethers@6.12.2)(hardhat@2.22.17(ts-node@10.9.2(@swc/core@1.4.15)(@types/node@20.10.6)(typescript@5.5.3))(typescript@5.5.3)))(@swc/core@1.6.5)(@types/node@20.10.6)(encoding@0.1.13)(ethers@6.12.2)(ts-node@10.9.2(@swc/core@1.4.15)(@types/node@20.10.6)(typescript@5.5.3))(typescript@5.5.3)
       '@openzeppelin/merkle-tree': 1.0.7
       '@swc/core': 1.6.5
       ajv: 8.16.0
-      axios: 1.7.7
+      axios: 1.7.9
       dotenv: 16.4.5
       rollup-plugin-swc3: 0.11.2(@swc/core@1.6.5)(rollup@4.12.0)
-      viem: 2.21.49(typescript@5.5.3)(zod@3.23.8)
+      viem: 2.21.51(typescript@5.5.3)(zod@3.23.8)
       zod: 3.23.8
     transitivePeerDependencies:
       - '@nomicfoundation/hardhat-ethers'
@@ -9688,38 +9678,38 @@ snapshots:
       '@nomicfoundation/ethereumjs-rlp': 5.0.4
       ethereum-cryptography: 0.1.3
 
-  '@nomicfoundation/hardhat-ethers@3.0.6(ethers@6.12.2)(hardhat@2.22.16(ts-node@10.9.2(@swc/core@1.4.15)(@types/node@20.10.6)(typescript@5.5.3))(typescript@5.5.3))':
+  '@nomicfoundation/hardhat-ethers@3.0.6(ethers@6.12.2)(hardhat@2.22.17(ts-node@10.9.2(@swc/core@1.4.15)(@types/node@20.10.6)(typescript@5.5.3))(typescript@5.5.3))':
     dependencies:
       debug: 4.3.6
       ethers: 6.12.2
-      hardhat: 2.22.16(ts-node@10.9.2(@swc/core@1.4.15)(@types/node@20.10.6)(typescript@5.5.3))(typescript@5.5.3)
+      hardhat: 2.22.17(ts-node@10.9.2(@swc/core@1.4.15)(@types/node@20.10.6)(typescript@5.5.3))(typescript@5.5.3)
       lodash.isequal: 4.5.0
     transitivePeerDependencies:
       - supports-color
 
-  '@nomicfoundation/hardhat-ignition@0.15.5(@nomicfoundation/hardhat-verify@2.0.9(hardhat@2.22.16(ts-node@10.9.2(@swc/core@1.4.15)(@types/node@20.10.6)(typescript@5.5.3))(typescript@5.5.3)))(hardhat@2.22.16(ts-node@10.9.2(@swc/core@1.4.15)(@types/node@20.10.6)(typescript@5.5.3))(typescript@5.5.3))':
+  '@nomicfoundation/hardhat-ignition@0.15.5(@nomicfoundation/hardhat-verify@2.0.9(hardhat@2.22.17(ts-node@10.9.2(@swc/core@1.4.15)(@types/node@20.10.6)(typescript@5.5.3))(typescript@5.5.3)))(hardhat@2.22.17(ts-node@10.9.2(@swc/core@1.4.15)(@types/node@20.10.6)(typescript@5.5.3))(typescript@5.5.3))':
     dependencies:
-      '@nomicfoundation/hardhat-verify': 2.0.9(hardhat@2.22.16(ts-node@10.9.2(@swc/core@1.4.15)(@types/node@20.10.6)(typescript@5.5.3))(typescript@5.5.3))
+      '@nomicfoundation/hardhat-verify': 2.0.9(hardhat@2.22.17(ts-node@10.9.2(@swc/core@1.4.15)(@types/node@20.10.6)(typescript@5.5.3))(typescript@5.5.3))
       '@nomicfoundation/ignition-core': 0.15.5
       '@nomicfoundation/ignition-ui': 0.15.5
       chalk: 4.1.2
       debug: 4.3.6
       fs-extra: 10.1.0
-      hardhat: 2.22.16(ts-node@10.9.2(@swc/core@1.4.15)(@types/node@20.10.6)(typescript@5.5.3))(typescript@5.5.3)
+      hardhat: 2.22.17(ts-node@10.9.2(@swc/core@1.4.15)(@types/node@20.10.6)(typescript@5.5.3))(typescript@5.5.3)
       prompts: 2.4.2
     transitivePeerDependencies:
       - bufferutil
       - supports-color
       - utf-8-validate
 
-  '@nomicfoundation/hardhat-verify@2.0.9(hardhat@2.22.16(ts-node@10.9.2(@swc/core@1.4.15)(@types/node@20.10.6)(typescript@5.5.3))(typescript@5.5.3))':
+  '@nomicfoundation/hardhat-verify@2.0.9(hardhat@2.22.17(ts-node@10.9.2(@swc/core@1.4.15)(@types/node@20.10.6)(typescript@5.5.3))(typescript@5.5.3))':
     dependencies:
       '@ethersproject/abi': 5.7.0
       '@ethersproject/address': 5.7.0
       cbor: 8.1.0
       chalk: 2.4.2
       debug: 4.3.6
-      hardhat: 2.22.16(ts-node@10.9.2(@swc/core@1.4.15)(@types/node@20.10.6)(typescript@5.5.3))(typescript@5.5.3)
+      hardhat: 2.22.17(ts-node@10.9.2(@swc/core@1.4.15)(@types/node@20.10.6)(typescript@5.5.3))(typescript@5.5.3)
       lodash.clonedeep: 4.5.0
       semver: 6.3.1
       table: 6.8.2
@@ -10076,9 +10066,9 @@ snapshots:
       - debug
       - encoding
 
-  '@openzeppelin/hardhat-upgrades@3.2.1(@nomicfoundation/hardhat-ethers@3.0.6(ethers@6.12.2)(hardhat@2.22.16(ts-node@10.9.2(@swc/core@1.4.15)(@types/node@20.10.6)(typescript@5.5.3))(typescript@5.5.3)))(@nomicfoundation/hardhat-verify@2.0.9(hardhat@2.22.16(ts-node@10.9.2(@swc/core@1.4.15)(@types/node@20.10.6)(typescript@5.5.3))(typescript@5.5.3)))(encoding@0.1.13)(ethers@6.12.2)(hardhat@2.22.16(ts-node@10.9.2(@swc/core@1.4.15)(@types/node@20.10.6)(typescript@5.5.3))(typescript@5.5.3))':
+  '@openzeppelin/hardhat-upgrades@3.2.1(@nomicfoundation/hardhat-ethers@3.0.6(ethers@6.12.2)(hardhat@2.22.17(ts-node@10.9.2(@swc/core@1.4.15)(@types/node@20.10.6)(typescript@5.5.3))(typescript@5.5.3)))(@nomicfoundation/hardhat-verify@2.0.9(hardhat@2.22.17(ts-node@10.9.2(@swc/core@1.4.15)(@types/node@20.10.6)(typescript@5.5.3))(typescript@5.5.3)))(encoding@0.1.13)(ethers@6.12.2)(hardhat@2.22.17(ts-node@10.9.2(@swc/core@1.4.15)(@types/node@20.10.6)(typescript@5.5.3))(typescript@5.5.3))':
     dependencies:
-      '@nomicfoundation/hardhat-ethers': 3.0.6(ethers@6.12.2)(hardhat@2.22.16(ts-node@10.9.2(@swc/core@1.4.15)(@types/node@20.10.6)(typescript@5.5.3))(typescript@5.5.3))
+      '@nomicfoundation/hardhat-ethers': 3.0.6(ethers@6.12.2)(hardhat@2.22.17(ts-node@10.9.2(@swc/core@1.4.15)(@types/node@20.10.6)(typescript@5.5.3))(typescript@5.5.3))
       '@openzeppelin/defender-sdk-base-client': 1.14.3(encoding@0.1.13)
       '@openzeppelin/defender-sdk-deploy-client': 1.14.3(debug@4.3.6)(encoding@0.1.13)
       '@openzeppelin/defender-sdk-network-client': 1.14.3(debug@4.3.6)(encoding@0.1.13)
@@ -10087,11 +10077,11 @@ snapshots:
       debug: 4.3.6
       ethereumjs-util: 7.1.5
       ethers: 6.12.2
-      hardhat: 2.22.16(ts-node@10.9.2(@swc/core@1.4.15)(@types/node@20.10.6)(typescript@5.5.3))(typescript@5.5.3)
+      hardhat: 2.22.17(ts-node@10.9.2(@swc/core@1.4.15)(@types/node@20.10.6)(typescript@5.5.3))(typescript@5.5.3)
       proper-lockfile: 4.1.2
       undici: 6.19.7
     optionalDependencies:
-      '@nomicfoundation/hardhat-verify': 2.0.9(hardhat@2.22.16(ts-node@10.9.2(@swc/core@1.4.15)(@types/node@20.10.6)(typescript@5.5.3))(typescript@5.5.3))
+      '@nomicfoundation/hardhat-verify': 2.0.9(hardhat@2.22.17(ts-node@10.9.2(@swc/core@1.4.15)(@types/node@20.10.6)(typescript@5.5.3))(typescript@5.5.3))
     transitivePeerDependencies:
       - encoding
       - supports-color
@@ -10295,7 +10285,7 @@ snapshots:
 
   '@safe-global/protocol-kit@5.0.4(typescript@5.5.3)(zod@3.23.8)':
     dependencies:
-      '@noble/hashes': 1.4.0
+      '@noble/hashes': 1.5.0
       '@safe-global/safe-deployments': 1.37.18
       '@safe-global/safe-modules-deployments': 2.2.4
       '@safe-global/types-kit': 1.0.0(typescript@5.5.3)(zod@3.23.8)
@@ -10352,7 +10342,7 @@ snapshots:
     dependencies:
       '@noble/curves': 1.4.2
       '@noble/hashes': 1.4.0
-      '@scure/base': 1.1.7
+      '@scure/base': 1.1.9
 
   '@scure/bip32@1.5.0':
     dependencies:
@@ -10601,10 +10591,10 @@ snapshots:
       - encoding
       - supports-color
 
-  '@starboardventures/hardhat-verify@1.0.1(hardhat@2.22.16(ts-node@10.9.2(@swc/core@1.4.15)(@types/node@20.10.6)(typescript@5.5.3))(typescript@5.5.3))':
+  '@starboardventures/hardhat-verify@1.0.1(hardhat@2.22.17(ts-node@10.9.2(@swc/core@1.4.15)(@types/node@20.10.6)(typescript@5.5.3))(typescript@5.5.3))':
     dependencies:
       fs-extra: 11.2.0
-      hardhat: 2.22.16(ts-node@10.9.2(@swc/core@1.4.15)(@types/node@20.10.6)(typescript@5.5.3))(typescript@5.5.3)
+      hardhat: 2.22.17(ts-node@10.9.2(@swc/core@1.4.15)(@types/node@20.10.6)(typescript@5.5.3))(typescript@5.5.3)
       node-fetch: 2.0.0
 
   '@storacha/one-webcrypto@1.0.1': {}
@@ -10651,7 +10641,7 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  '@swc/cli@0.3.12(@swc/core@1.4.15)(chokidar@4.0.1)':
+  '@swc/cli@0.3.12(@swc/core@1.4.15)(chokidar@3.6.0)':
     dependencies:
       '@mole-inc/bin-wrapper': 8.0.1
       '@swc/core': 1.4.15
@@ -10664,7 +10654,7 @@ snapshots:
       slash: 3.0.0
       source-map: 0.7.4
     optionalDependencies:
-      chokidar: 4.0.1
+      chokidar: 3.6.0
 
   '@swc/core-darwin-arm64@1.4.15':
     optional: true
@@ -10772,17 +10762,17 @@ snapshots:
     dependencies:
       defer-to-connect: 2.0.1
 
-  '@tenderly/hardhat-tenderly@2.3.0(@nomicfoundation/hardhat-ethers@3.0.6(ethers@6.12.2)(hardhat@2.22.16(ts-node@10.9.2(@swc/core@1.4.15)(@types/node@20.10.6)(typescript@5.5.3))(typescript@5.5.3)))(@swc/core@1.4.15)(@types/node@20.10.6)(encoding@0.1.13)(ethers@6.12.2)(hardhat@2.22.16(ts-node@10.9.2(@swc/core@1.4.15)(@types/node@20.10.6)(typescript@5.5.3))(typescript@5.5.3))':
+  '@tenderly/hardhat-tenderly@2.3.0(@nomicfoundation/hardhat-ethers@3.0.6(ethers@6.12.2)(hardhat@2.22.17(ts-node@10.9.2(@swc/core@1.4.15)(@types/node@20.10.6)(typescript@5.5.3))(typescript@5.5.3)))(@swc/core@1.4.15)(@types/node@20.10.6)(encoding@0.1.13)(ethers@6.12.2)(hardhat@2.22.17(ts-node@10.9.2(@swc/core@1.4.15)(@types/node@20.10.6)(typescript@5.5.3))(typescript@5.5.3))':
     dependencies:
       '@ethersproject/bignumber': 5.7.0
-      '@nomicfoundation/hardhat-ignition': 0.15.5(@nomicfoundation/hardhat-verify@2.0.9(hardhat@2.22.16(ts-node@10.9.2(@swc/core@1.4.15)(@types/node@20.10.6)(typescript@5.5.3))(typescript@5.5.3)))(hardhat@2.22.16(ts-node@10.9.2(@swc/core@1.4.15)(@types/node@20.10.6)(typescript@5.5.3))(typescript@5.5.3))
-      '@nomicfoundation/hardhat-verify': 2.0.9(hardhat@2.22.16(ts-node@10.9.2(@swc/core@1.4.15)(@types/node@20.10.6)(typescript@5.5.3))(typescript@5.5.3))
-      '@openzeppelin/hardhat-upgrades': 3.2.1(@nomicfoundation/hardhat-ethers@3.0.6(ethers@6.12.2)(hardhat@2.22.16(ts-node@10.9.2(@swc/core@1.4.15)(@types/node@20.10.6)(typescript@5.5.3))(typescript@5.5.3)))(@nomicfoundation/hardhat-verify@2.0.9(hardhat@2.22.16(ts-node@10.9.2(@swc/core@1.4.15)(@types/node@20.10.6)(typescript@5.5.3))(typescript@5.5.3)))(encoding@0.1.13)(ethers@6.12.2)(hardhat@2.22.16(ts-node@10.9.2(@swc/core@1.4.15)(@types/node@20.10.6)(typescript@5.5.3))(typescript@5.5.3))
+      '@nomicfoundation/hardhat-ignition': 0.15.5(@nomicfoundation/hardhat-verify@2.0.9(hardhat@2.22.17(ts-node@10.9.2(@swc/core@1.4.15)(@types/node@20.10.6)(typescript@5.5.3))(typescript@5.5.3)))(hardhat@2.22.17(ts-node@10.9.2(@swc/core@1.4.15)(@types/node@20.10.6)(typescript@5.5.3))(typescript@5.5.3))
+      '@nomicfoundation/hardhat-verify': 2.0.9(hardhat@2.22.17(ts-node@10.9.2(@swc/core@1.4.15)(@types/node@20.10.6)(typescript@5.5.3))(typescript@5.5.3))
+      '@openzeppelin/hardhat-upgrades': 3.2.1(@nomicfoundation/hardhat-ethers@3.0.6(ethers@6.12.2)(hardhat@2.22.17(ts-node@10.9.2(@swc/core@1.4.15)(@types/node@20.10.6)(typescript@5.5.3))(typescript@5.5.3)))(@nomicfoundation/hardhat-verify@2.0.9(hardhat@2.22.17(ts-node@10.9.2(@swc/core@1.4.15)(@types/node@20.10.6)(typescript@5.5.3))(typescript@5.5.3)))(encoding@0.1.13)(ethers@6.12.2)(hardhat@2.22.17(ts-node@10.9.2(@swc/core@1.4.15)(@types/node@20.10.6)(typescript@5.5.3))(typescript@5.5.3))
       '@openzeppelin/upgrades-core': 1.35.1
       axios: 1.7.2(debug@4.3.6)
       ethers: 6.12.2
       fs-extra: 10.1.0
-      hardhat: 2.22.16(ts-node@10.9.2(@swc/core@1.4.15)(@types/node@20.10.6)(typescript@5.5.3))(typescript@5.5.3)
+      hardhat: 2.22.17(ts-node@10.9.2(@swc/core@1.4.15)(@types/node@20.10.6)(typescript@5.5.3))(typescript@5.5.3)
       hardhat-deploy: 0.11.45
       tenderly: 0.9.1(ts-node@10.9.2(@swc/core@1.4.15)(@types/node@20.10.6)(typescript@5.5.3))(typescript@5.5.4)
       ts-node: 10.9.2(@swc/core@1.4.15)(@types/node@20.10.6)(typescript@5.5.4)
@@ -10799,17 +10789,17 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@tenderly/hardhat-tenderly@2.3.0(@nomicfoundation/hardhat-ethers@3.0.6(ethers@6.12.2)(hardhat@2.22.16(ts-node@10.9.2(@swc/core@1.4.15)(@types/node@20.10.6)(typescript@5.5.3))(typescript@5.5.3)))(@swc/core@1.6.5)(@types/node@20.10.6)(encoding@0.1.13)(ethers@6.12.2)(hardhat@2.22.16(ts-node@10.9.2(@swc/core@1.4.15)(@types/node@20.10.6)(typescript@5.5.3))(typescript@5.5.3))':
+  '@tenderly/hardhat-tenderly@2.3.0(@nomicfoundation/hardhat-ethers@3.0.6(ethers@6.12.2)(hardhat@2.22.17(ts-node@10.9.2(@swc/core@1.4.15)(@types/node@20.10.6)(typescript@5.5.3))(typescript@5.5.3)))(@swc/core@1.6.5)(@types/node@20.10.6)(encoding@0.1.13)(ethers@6.12.2)(hardhat@2.22.17(ts-node@10.9.2(@swc/core@1.4.15)(@types/node@20.10.6)(typescript@5.5.3))(typescript@5.5.3))':
     dependencies:
       '@ethersproject/bignumber': 5.7.0
-      '@nomicfoundation/hardhat-ignition': 0.15.5(@nomicfoundation/hardhat-verify@2.0.9(hardhat@2.22.16(ts-node@10.9.2(@swc/core@1.4.15)(@types/node@20.10.6)(typescript@5.5.3))(typescript@5.5.3)))(hardhat@2.22.16(ts-node@10.9.2(@swc/core@1.4.15)(@types/node@20.10.6)(typescript@5.5.3))(typescript@5.5.3))
-      '@nomicfoundation/hardhat-verify': 2.0.9(hardhat@2.22.16(ts-node@10.9.2(@swc/core@1.4.15)(@types/node@20.10.6)(typescript@5.5.3))(typescript@5.5.3))
-      '@openzeppelin/hardhat-upgrades': 3.2.1(@nomicfoundation/hardhat-ethers@3.0.6(ethers@6.12.2)(hardhat@2.22.16(ts-node@10.9.2(@swc/core@1.4.15)(@types/node@20.10.6)(typescript@5.5.3))(typescript@5.5.3)))(@nomicfoundation/hardhat-verify@2.0.9(hardhat@2.22.16(ts-node@10.9.2(@swc/core@1.4.15)(@types/node@20.10.6)(typescript@5.5.3))(typescript@5.5.3)))(encoding@0.1.13)(ethers@6.12.2)(hardhat@2.22.16(ts-node@10.9.2(@swc/core@1.4.15)(@types/node@20.10.6)(typescript@5.5.3))(typescript@5.5.3))
+      '@nomicfoundation/hardhat-ignition': 0.15.5(@nomicfoundation/hardhat-verify@2.0.9(hardhat@2.22.17(ts-node@10.9.2(@swc/core@1.4.15)(@types/node@20.10.6)(typescript@5.5.3))(typescript@5.5.3)))(hardhat@2.22.17(ts-node@10.9.2(@swc/core@1.4.15)(@types/node@20.10.6)(typescript@5.5.3))(typescript@5.5.3))
+      '@nomicfoundation/hardhat-verify': 2.0.9(hardhat@2.22.17(ts-node@10.9.2(@swc/core@1.4.15)(@types/node@20.10.6)(typescript@5.5.3))(typescript@5.5.3))
+      '@openzeppelin/hardhat-upgrades': 3.2.1(@nomicfoundation/hardhat-ethers@3.0.6(ethers@6.12.2)(hardhat@2.22.17(ts-node@10.9.2(@swc/core@1.4.15)(@types/node@20.10.6)(typescript@5.5.3))(typescript@5.5.3)))(@nomicfoundation/hardhat-verify@2.0.9(hardhat@2.22.17(ts-node@10.9.2(@swc/core@1.4.15)(@types/node@20.10.6)(typescript@5.5.3))(typescript@5.5.3)))(encoding@0.1.13)(ethers@6.12.2)(hardhat@2.22.17(ts-node@10.9.2(@swc/core@1.4.15)(@types/node@20.10.6)(typescript@5.5.3))(typescript@5.5.3))
       '@openzeppelin/upgrades-core': 1.35.1
       axios: 1.7.2(debug@4.3.6)
       ethers: 6.12.2
       fs-extra: 10.1.0
-      hardhat: 2.22.16(ts-node@10.9.2(@swc/core@1.4.15)(@types/node@20.10.6)(typescript@5.5.3))(typescript@5.5.3)
+      hardhat: 2.22.17(ts-node@10.9.2(@swc/core@1.4.15)(@types/node@20.10.6)(typescript@5.5.3))(typescript@5.5.3)
       hardhat-deploy: 0.11.45
       tenderly: 0.9.1(ts-node@10.9.2(@swc/core@1.4.15)(@types/node@20.10.6)(typescript@5.5.3))(typescript@5.5.4)
       ts-node: 10.9.2(@swc/core@1.6.5)(@types/node@20.10.6)(typescript@5.5.4)
@@ -11504,11 +11494,6 @@ snapshots:
       typescript: 5.5.3
       zod: 3.23.8
 
-  abitype@1.0.6(typescript@5.5.3)(zod@3.23.8):
-    optionalDependencies:
-      typescript: 5.5.3
-      zod: 3.23.8
-
   abort-controller@3.0.0:
     dependencies:
       event-target-shim: 5.0.1
@@ -11759,7 +11744,7 @@ snapshots:
     transitivePeerDependencies:
       - debug
 
-  axios@1.7.7:
+  axios@1.7.9:
     dependencies:
       follow-redirects: 1.15.6(debug@4.3.6)
       form-data: 4.0.0
@@ -12849,7 +12834,7 @@ snapshots:
 
   ethereum-bloom-filters@1.2.0:
     dependencies:
-      '@noble/hashes': 1.4.0
+      '@noble/hashes': 1.5.0
 
   ethereum-cryptography@0.1.3:
     dependencies:
@@ -13573,7 +13558,7 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  hardhat@2.22.16(ts-node@10.9.2(@swc/core@1.4.15)(@types/node@20.10.6)(typescript@5.5.3))(typescript@5.5.3):
+  hardhat@2.22.17(ts-node@10.9.2(@swc/core@1.4.15)(@types/node@20.10.6)(typescript@5.5.3))(typescript@5.5.3):
     dependencies:
       '@ethersproject/abi': 5.7.0
       '@metamask/eth-sig-util': 4.0.1
@@ -14021,10 +14006,6 @@ snapshots:
   isows@1.0.3(ws@8.13.0):
     dependencies:
       ws: 8.13.0
-
-  isows@1.0.6(ws@8.18.0):
-    dependencies:
-      ws: 8.18.0
 
   isows@1.0.6(ws@8.18.0):
     dependencies:
@@ -16260,24 +16241,6 @@ snapshots:
       abitype: 0.10.0(typescript@5.5.3)(zod@3.23.8)
       isows: 1.0.3(ws@8.13.0)
       ws: 8.13.0
-    optionalDependencies:
-      typescript: 5.5.3
-    transitivePeerDependencies:
-      - bufferutil
-      - utf-8-validate
-      - zod
-
-  viem@2.21.49(typescript@5.5.3)(zod@3.23.8):
-    dependencies:
-      '@noble/curves': 1.6.0
-      '@noble/hashes': 1.5.0
-      '@scure/bip32': 1.5.0
-      '@scure/bip39': 1.4.0
-      abitype: 1.0.6(typescript@5.5.3)(zod@3.23.8)
-      isows: 1.0.6(ws@8.18.0)
-      ox: 0.1.2(typescript@5.5.3)(zod@3.23.8)
-      webauthn-p256: 0.0.10
-      ws: 8.18.0
     optionalDependencies:
       typescript: 5.5.3
     transitivePeerDependencies:

--- a/schema.graphql
+++ b/schema.graphql
@@ -460,6 +460,11 @@ type GetSalesResponse {
   data: [Sale!]
 }
 
+type GetSignatureRequestResponse {
+  count: Int
+  data: [SignatureRequest!]
+}
+
 type GetUsersResponse {
   count: Int
   data: [User!]
@@ -505,6 +510,9 @@ type HyperboardOwner {
   """The display name of the user"""
   display_name: String
   percentage_owned: Float!
+
+  """Pending signature requests for the user"""
+  signature_requests: [SignatureRequest!]
 }
 
 input HyperboardSortOptions {
@@ -832,6 +840,7 @@ type Query {
   metadata(first: Int, offset: Int, sort: MetadataFetchInput, where: MetadataWhereInput): GetMetadataResponse!
   orders(first: Int, offset: Int, sort: OrderFetchInput, where: OrderWhereInput): GetOrdersResponse!
   sales(first: Int, offset: Int, sort: SaleFetchInput, where: SaleWhereInput): GetSalesResponse!
+  signatureRequests(first: Int, offset: Int, sort: SignatureRequestFetchInput, where: SignatureRequestWhereInput): GetSignatureRequestResponse!
   users(first: Int, offset: Int, where: UserWhereInput): GetUsersResponse!
 }
 
@@ -941,12 +950,79 @@ type SectionEntryOwner {
   """The display name of the user"""
   display_name: String
   percentage: Float!
+
+  """Pending signature requests for the user"""
+  signature_requests: [SignatureRequest!]
   units: BigInt
 }
 
 type SectionResponseType {
   count: Float!
   data: [Section!]!
+}
+
+"""Pending signature request for a user"""
+type SignatureRequest {
+  """The chain ID of the signature request"""
+  chain_id: EthBigInt!
+
+  """The message data in JSON format"""
+  message: String!
+
+  """The hash of the Safe message (not the message to be signed)"""
+  message_hash: String!
+
+  """The purpose of the signature request"""
+  purpose: SignatureRequestPurpose!
+
+  """The safe address of the user who needs to sign"""
+  safe_address: String!
+
+  """The status of the signature request"""
+  status: SignatureRequestStatus!
+
+  """Timestamp of when the signature request was created"""
+  timestamp: EthBigInt!
+}
+
+input SignatureRequestFetchInput {
+  by: SignatureRequestSortOptions
+}
+
+"""Purpose of the signature request"""
+enum SignatureRequestPurpose {
+  UPDATE_USER_DATA
+}
+
+input SignatureRequestPurposeSearchOptions {
+  eq: SignatureRequestPurpose
+}
+
+input SignatureRequestSortOptions {
+  message_hash: SortOrder
+  purpose: SortOrder
+  safe_address: SortOrder
+  timestamp: SortOrder
+}
+
+"""Status of the signature request"""
+enum SignatureRequestStatus {
+  CANCELED
+  EXECUTED
+  PENDING
+}
+
+input SignatureRequestStatusSearchOptions {
+  eq: SignatureRequestStatus
+}
+
+input SignatureRequestWhereInput {
+  chain_id: BigIntSearchOptions
+  message_hash: StringSearchOptions
+  purpose: SignatureRequestPurposeSearchOptions
+  safe_address: StringSearchOptions
+  status: SignatureRequestStatusSearchOptions
+  timestamp: BigIntSearchOptions
 }
 
 """The direction to sort the query results"""
@@ -988,6 +1064,9 @@ type User {
 
   """The display name of the user"""
   display_name: String
+
+  """Pending signature requests for the user"""
+  signature_requests: [SignatureRequest!]
 }
 
 input UserWhereInput {

--- a/src/__generated__/routes/routes.ts
+++ b/src/__generated__/routes/routes.ts
@@ -395,6 +395,35 @@ export function RegisterRoutes(app: Router) {
             }
         });
         // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+        app.post('/v1/signature-requests/process',
+            ...(fetchMiddlewares<RequestHandler>(SignatureRequestController)),
+            ...(fetchMiddlewares<RequestHandler>(SignatureRequestController.prototype.processSignatureRequests)),
+
+            async function SignatureRequestController_processSignatureRequests(request: ExRequest, response: ExResponse, next: any) {
+            const args: Record<string, TsoaRoute.ParameterSchema> = {
+            };
+
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({ args, request, response });
+
+                const controller = new SignatureRequestController();
+
+              await templateService.apiHandler({
+                methodName: 'processSignatureRequests',
+                controller,
+                response,
+                next,
+                validatedArgs,
+                successStatus: 200,
+              });
+            } catch (err) {
+                return next(err);
+            }
+        });
+        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
         app.post('/v1/metadata',
             ...(fetchMiddlewares<RequestHandler>(MetadataController)),
             ...(fetchMiddlewares<RequestHandler>(MetadataController.prototype.storeMetadata)),

--- a/src/__generated__/routes/routes.ts
+++ b/src/__generated__/routes/routes.ts
@@ -51,15 +51,31 @@ const models: TsoaRoute.Models = {
         "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"errors":{"dataType":"union","subSchemas":[{"ref":"Record_string.string-or-string-Array_"},{"dataType":"array","array":{"dataType":"refObject","ref":"Error"}}]},"message":{"dataType":"string"},"data":{"dataType":"void"},"success":{"dataType":"boolean","required":true}},"validators":{}},
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "AddOrUpdateUserRequest": {
+    "EOAUserUpsertRequest": {
         "dataType": "refObject",
         "properties": {
-            "display_name": {"dataType":"string","required":true},
-            "avatar": {"dataType":"string","required":true},
-            "signature": {"dataType":"string","required":true},
             "chain_id": {"dataType":"double","required":true},
+            "type": {"dataType":"enum","enums":["eoa"],"required":true},
+            "display_name": {"dataType":"string"},
+            "avatar": {"dataType":"string"},
+            "signature": {"dataType":"string","required":true},
         },
         "additionalProperties": false,
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    "MultisigUserUpsertRequest": {
+        "dataType": "refObject",
+        "properties": {
+            "chain_id": {"dataType":"double","required":true},
+            "type": {"dataType":"enum","enums":["multisig"],"required":true},
+            "messageHash": {"dataType":"string","required":true},
+        },
+        "additionalProperties": false,
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    "AddOrUpdateUserRequest": {
+        "dataType": "refAlias",
+        "type": {"dataType":"union","subSchemas":[{"ref":"EOAUserUpsertRequest"},{"ref":"MultisigUserUpsertRequest"}],"validators":{}},
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     "ApiResponse__cid-string__": {

--- a/src/__generated__/routes/routes.ts
+++ b/src/__generated__/routes/routes.ts
@@ -5,6 +5,8 @@ import { TsoaRoute, fetchMiddlewares, ExpressTemplateService } from '@tsoa/runti
 // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
 import { UserController } from './../../controllers/UserController.js';
 // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+import { SignatureRequestController } from './../../controllers/SignatureRequestController.js';
+// WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
 import { MetadataController } from './../../controllers/MetadataController.js';
 // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
 import { MarketplaceController } from './../../controllers/MarketplaceController.js';
@@ -76,6 +78,16 @@ const models: TsoaRoute.Models = {
     "AddOrUpdateUserRequest": {
         "dataType": "refAlias",
         "type": {"dataType":"union","subSchemas":[{"ref":"EOAUserUpsertRequest"},{"ref":"MultisigUserUpsertRequest"}],"validators":{}},
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    "CancelSignatureRequest": {
+        "dataType": "refObject",
+        "properties": {
+            "signature": {"dataType":"string","required":true},
+            "owner_address": {"dataType":"string","required":true},
+            "chain_id": {"dataType":"double","required":true},
+        },
+        "additionalProperties": false,
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     "ApiResponse__cid-string__": {
@@ -345,6 +357,38 @@ export function RegisterRoutes(app: Router) {
                 next,
                 validatedArgs,
                 successStatus: 201,
+              });
+            } catch (err) {
+                return next(err);
+            }
+        });
+        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+        app.post('/v1/signature-requests/:safe_address-:message_hash/cancel',
+            ...(fetchMiddlewares<RequestHandler>(SignatureRequestController)),
+            ...(fetchMiddlewares<RequestHandler>(SignatureRequestController.prototype.cancelSignatureRequest)),
+
+            async function SignatureRequestController_cancelSignatureRequest(request: ExRequest, response: ExResponse, next: any) {
+            const args: Record<string, TsoaRoute.ParameterSchema> = {
+                    safe_address: {"in":"path","name":"safe_address","required":true,"dataType":"string"},
+                    message_hash: {"in":"path","name":"message_hash","required":true,"dataType":"string"},
+                    requestBody: {"in":"body","name":"requestBody","required":true,"ref":"CancelSignatureRequest"},
+            };
+
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({ args, request, response });
+
+                const controller = new SignatureRequestController();
+
+              await templateService.apiHandler({
+                methodName: 'cancelSignatureRequest',
+                controller,
+                response,
+                next,
+                validatedArgs,
+                successStatus: 200,
               });
             } catch (err) {
                 return next(err);

--- a/src/__generated__/swagger.json
+++ b/src/__generated__/swagger.json
@@ -182,6 +182,27 @@
 					}
 				]
 			},
+			"CancelSignatureRequest": {
+				"properties": {
+					"signature": {
+						"type": "string"
+					},
+					"owner_address": {
+						"type": "string"
+					},
+					"chain_id": {
+						"type": "number",
+						"format": "double"
+					}
+				},
+				"required": [
+					"signature",
+					"owner_address",
+					"chain_id"
+				],
+				"type": "object",
+				"additionalProperties": false
+			},
 			"ApiResponse__cid-string__": {
 				"properties": {
 					"errors": {
@@ -1191,6 +1212,73 @@
 										"messageHash": "0x1234567890abcdef"
 									}
 								}
+							}
+						}
+					}
+				}
+			}
+		},
+		"/v1/signature-requests/{safe_address}-{message_hash}/cancel": {
+			"post": {
+				"operationId": "CancelSignatureRequest",
+				"responses": {
+					"200": {
+						"description": "Signature request canceled successfully",
+						"content": {
+							"application/json": {
+								"schema": {
+									"properties": {
+										"message": {
+											"type": "string"
+										},
+										"success": {
+											"type": "boolean"
+										}
+									},
+									"required": [
+										"message",
+										"success"
+									],
+									"type": "object"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					},
+					"404": {
+						"description": "Signature request not found"
+					}
+				},
+				"tags": [
+					"SignatureRequests"
+				],
+				"security": [],
+				"parameters": [
+					{
+						"in": "path",
+						"name": "safe_address",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "path",
+						"name": "message_hash",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					}
+				],
+				"requestBody": {
+					"required": true,
+					"content": {
+						"application/json": {
+							"schema": {
+								"$ref": "#/components/schemas/CancelSignatureRequest"
 							}
 						}
 					}

--- a/src/__generated__/swagger.json
+++ b/src/__generated__/swagger.json
@@ -1285,6 +1285,40 @@
 				}
 			}
 		},
+		"/v1/signature-requests/process": {
+			"post": {
+				"operationId": "ProcessSignatureRequests",
+				"responses": {
+					"200": {
+						"description": "Signature requests processing started",
+						"content": {
+							"application/json": {
+								"schema": {
+									"properties": {
+										"message": {
+											"type": "string"
+										},
+										"success": {
+											"type": "boolean"
+										}
+									},
+									"required": [
+										"message",
+										"success"
+									],
+									"type": "object"
+								}
+							}
+						}
+					}
+				},
+				"tags": [
+					"SignatureRequests"
+				],
+				"security": [],
+				"parameters": []
+			}
+		},
 		"/v1/metadata": {
 			"post": {
 				"operationId": "StoreMetadata",

--- a/src/__generated__/swagger.json
+++ b/src/__generated__/swagger.json
@@ -116,9 +116,19 @@
 				"type": "object",
 				"description": "Interface for a generic API response."
 			},
-			"AddOrUpdateUserRequest": {
-				"description": "Interface for a user add or update request.",
+			"EOAUserUpsertRequest": {
 				"properties": {
+					"chain_id": {
+						"type": "number",
+						"format": "double"
+					},
+					"type": {
+						"type": "string",
+						"enum": [
+							"eoa"
+						],
+						"nullable": false
+					},
 					"display_name": {
 						"type": "string"
 					},
@@ -127,20 +137,50 @@
 					},
 					"signature": {
 						"type": "string"
-					},
-					"chain_id": {
-						"type": "number",
-						"format": "double"
 					}
 				},
 				"required": [
-					"display_name",
-					"avatar",
-					"signature",
-					"chain_id"
+					"chain_id",
+					"type",
+					"signature"
 				],
 				"type": "object",
 				"additionalProperties": false
+			},
+			"MultisigUserUpsertRequest": {
+				"properties": {
+					"chain_id": {
+						"type": "number",
+						"format": "double"
+					},
+					"type": {
+						"type": "string",
+						"enum": [
+							"multisig"
+						],
+						"nullable": false
+					},
+					"messageHash": {
+						"type": "string"
+					}
+				},
+				"required": [
+					"chain_id",
+					"type",
+					"messageHash"
+				],
+				"type": "object",
+				"additionalProperties": false
+			},
+			"AddOrUpdateUserRequest": {
+				"anyOf": [
+					{
+						"$ref": "#/components/schemas/EOAUserUpsertRequest"
+					},
+					{
+						"$ref": "#/components/schemas/MultisigUserUpsertRequest"
+					}
+				]
 			},
 			"ApiResponse__cid-string__": {
 				"properties": {
@@ -1133,6 +1173,24 @@
 						"application/json": {
 							"schema": {
 								"$ref": "#/components/schemas/AddOrUpdateUserRequest"
+							},
+							"examples": {
+								"Example 1": {
+									"value": {
+										"type": "eoa",
+										"chain_id": 11155111,
+										"display_name": "Dana's Profile",
+										"avatar": "https://example.com/avatar.png",
+										"signature": "0x1234567890abcdef"
+									}
+								},
+								"Example 2": {
+									"value": {
+										"type": "multisig",
+										"chain_id": 11155111,
+										"messageHash": "0x1234567890abcdef"
+									}
+								}
 							}
 						}
 					}

--- a/src/client/supabase.ts
+++ b/src/client/supabase.ts
@@ -204,6 +204,21 @@ const handleChangeOrders = (
   }
 };
 
+/* eslint-disable  @typescript-eslint/no-explicit-any */
+const handleChangeSignatureRequests = (
+  payload: RealtimePostgresChangesPayload<{ [key: string]: any }>,
+) => {
+  switch (payload.eventType) {
+    case "INSERT":
+    case "UPDATE":
+    case "DELETE":
+      cache.invalidate([{ typename: "SignatureRequest" }]);
+      break;
+    default:
+      break;
+  }
+};
+
 supabaseCaching
   .channel("schema-db-changes")
   .on(
@@ -401,5 +416,14 @@ supabaseData
       table: "marketplace_order_nonces",
     },
     (payload) => handleChangeOrders(payload),
+  )
+  .on(
+    "postgres_changes",
+    {
+      event: "*",
+      schema: "public",
+      table: "signature_requests",
+    },
+    (payload) => handleChangeSignatureRequests(payload),
   )
   .subscribe();

--- a/src/commands/CommandFactory.ts
+++ b/src/commands/CommandFactory.ts
@@ -1,0 +1,30 @@
+import { Database } from "../types/supabaseData.js";
+import { ISafeApiCommand } from "../types/safe-signatures.js";
+
+import { UserUpsertCommand } from "./UserUpsertCommand.js";
+import { SafeApiCommand } from "./SafeApiCommand.js";
+
+type SignatureRequest =
+  Database["public"]["Tables"]["signature_requests"]["Row"];
+
+export function getCommand(request: SignatureRequest): ISafeApiCommand {
+  switch (request.purpose) {
+    case "update_user_data":
+      return new UserUpsertCommand(
+        request.safe_address,
+        request.message_hash,
+        request.chain_id,
+      );
+    default:
+      console.warn("Unrecognized purpose:", request.purpose);
+      return new NoopCommand();
+  }
+}
+
+class NoopCommand extends SafeApiCommand implements ISafeApiCommand {
+  constructor() {
+    super("", "", 0);
+  }
+
+  async execute(): Promise<void> {}
+}

--- a/src/commands/SafeApiCommand.ts
+++ b/src/commands/SafeApiCommand.ts
@@ -1,0 +1,26 @@
+import SafeApiKit from "@safe-global/api-kit";
+
+import { SupabaseDataService } from "../services/SupabaseDataService.js";
+import { ISafeApiCommand } from "../types/safe-signatures.js";
+
+export abstract class SafeApiCommand implements ISafeApiCommand {
+  protected readonly safeAddress: string;
+  protected readonly messageHash: string;
+  protected readonly chainId: number;
+  protected readonly dataService: SupabaseDataService;
+  protected readonly safeApiKit: SafeApiKit.default;
+
+  constructor(safeAddress: string, messageHash: string, chainId: number) {
+    this.safeAddress = safeAddress;
+    this.messageHash = messageHash;
+    this.chainId = chainId;
+    this.dataService = new SupabaseDataService();
+    this.safeApiKit = new SafeApiKit.default({ chainId: BigInt(chainId) });
+  }
+
+  abstract execute(): Promise<void>;
+
+  getId(): string {
+    return `${this.chainId}-${this.safeAddress}-${this.messageHash}`;
+  }
+}

--- a/src/commands/UserUpsertCommand.ts
+++ b/src/commands/UserUpsertCommand.ts
@@ -1,0 +1,77 @@
+import { getAddress } from "viem";
+
+import {
+  MultisigUserUpdateMessage,
+  USER_UPDATE_MESSAGE_SCHEMA,
+} from "../lib/users/schemas.js";
+import { isTypedMessage } from "../utils/signatures.js";
+import UserUpsertSignatureVerifier from "../lib/safe-signature-verification/UserUpsertSignatureVerifier.js";
+import { Database } from "../types/supabaseData.js";
+
+import { SafeApiCommand } from "./SafeApiCommand.js";
+
+type SignatureRequest =
+  Database["public"]["Tables"]["signature_requests"]["Row"];
+
+export class UserUpsertCommand extends SafeApiCommand {
+  async execute(): Promise<void> {
+    const signatureRequest = await this.dataService.getSignatureRequest(
+      this.safeAddress,
+      this.messageHash,
+    );
+
+    if (!signatureRequest || signatureRequest.status !== "pending") {
+      return;
+    }
+
+    const safeMessage = await this.safeApiKit.getMessage(this.messageHash);
+
+    if (!isTypedMessage(safeMessage.message)) {
+      throw new Error("Unexpected message type: not EIP712TypedData");
+    }
+
+    const message = USER_UPDATE_MESSAGE_SCHEMA.safeParse(
+      safeMessage.message.message,
+    );
+    if (!message.success) {
+      console.error("Unexpected message format", message.error);
+      throw new Error("Unexpected message format");
+    }
+
+    const verifier = new UserUpsertSignatureVerifier(
+      Number(signatureRequest.chain_id),
+      getAddress(this.safeAddress),
+      message.data,
+    );
+
+    if (!(await verifier.verify(safeMessage.preparedSignature))) {
+      console.error(`Signature verification failed: ${this.getId()}`);
+      return;
+    }
+
+    await this.updateDatabase(signatureRequest, message.data);
+    console.log(`Signature request executed: ${this.getId()}`);
+  }
+
+  async updateDatabase(
+    signatureRequest: Exclude<SignatureRequest, undefined>,
+    message: MultisigUserUpdateMessage,
+  ): Promise<void> {
+    const users = await this.dataService.upsertUsers([
+      {
+        address: this.safeAddress,
+        chain_id: signatureRequest.chain_id,
+        display_name: message.user.displayName,
+        avatar: message.user.avatar,
+      },
+    ]);
+    if (!users.length) {
+      throw new Error("Error adding or updating user");
+    }
+    await this.dataService.updateSignatureRequestStatus(
+      this.safeAddress,
+      this.messageHash,
+      "executed",
+    );
+  }
+}

--- a/src/controllers/SignatureRequestController.ts
+++ b/src/controllers/SignatureRequestController.ts
@@ -1,0 +1,110 @@
+import {
+  Body,
+  Controller,
+  Post,
+  Path,
+  Response,
+  Route,
+  SuccessResponse,
+  Tags,
+} from "tsoa";
+
+import { SupabaseDataService } from "../services/SupabaseDataService.js";
+import { verifyAuthSignedData } from "../utils/verifyAuthSignedData.js";
+
+interface CancelSignatureRequest {
+  signature: string;
+  owner_address: string;
+  chain_id: number;
+}
+
+@Route("v1/signature-requests")
+@Tags("SignatureRequests")
+export class SignatureRequestController extends Controller {
+  private readonly dataService: SupabaseDataService;
+
+  constructor() {
+    super();
+    this.dataService = new SupabaseDataService();
+  }
+
+  @Post("{safe_address}-{message_hash}/cancel")
+  @SuccessResponse(200, "Signature request canceled successfully")
+  @Response(401, "Unauthorized")
+  @Response(404, "Signature request not found")
+  public async cancelSignatureRequest(
+    @Path() safe_address: string,
+    @Path() message_hash: string,
+    @Body() requestBody: CancelSignatureRequest,
+  ): Promise<{ success: boolean; message: string }> {
+    if (
+      !(await this.isValidSignature(safe_address, message_hash, requestBody))
+    ) {
+      return this.errorResponse("Unauthorized", 401);
+    }
+
+    const signatureRequest = await this.dataService.getSignatureRequest(
+      safe_address,
+      message_hash,
+    );
+    if (!signatureRequest) {
+      return this.errorResponse("Signature request not found", 404);
+    }
+
+    switch (signatureRequest.status) {
+      case "executed":
+        return this.errorResponse(
+          "Signature request has already been executed",
+        );
+
+      case "canceled":
+        return this.successResponse("Signature request canceled successfully");
+
+      case "pending":
+        await this.dataService.updateSignatureRequestStatus(
+          safe_address,
+          message_hash,
+          "canceled",
+        );
+        return this.successResponse("Signature request canceled successfully");
+
+      default:
+        return this.errorResponse(
+          `Invalid signature request status: ${signatureRequest.status}`,
+        );
+    }
+  }
+
+  async isValidSignature(
+    safeAddress: string,
+    messageHash: string,
+    requestBody: CancelSignatureRequest,
+  ): Promise<boolean> {
+    const { signature, owner_address, chain_id } = requestBody;
+    const id = `${safeAddress}-${messageHash}`;
+
+    return verifyAuthSignedData({
+      address: owner_address as `0x${string}`,
+      types: {
+        SignatureRequest: [
+          { name: "cancelSignatureRequestId", type: "string" },
+        ],
+      },
+      primaryType: "SignatureRequest",
+      signature: signature as `0x${string}`,
+      message: {
+        cancelSignatureRequestId: id,
+      },
+      requiredChainId: chain_id,
+    });
+  }
+
+  successResponse(message: string) {
+    return { success: true, message };
+  }
+
+  errorResponse(message: string, status = 400) {
+    this.setStatus(status);
+    return { success: false, message };
+  }
+}

--- a/src/controllers/SignatureRequestController.ts
+++ b/src/controllers/SignatureRequestController.ts
@@ -11,6 +11,7 @@ import {
 
 import { SupabaseDataService } from "../services/SupabaseDataService.js";
 import { verifyAuthSignedData } from "../utils/verifyAuthSignedData.js";
+import { SignatureRequestProcessor } from "../services/SignatureRequestProcessor.js";
 
 interface CancelSignatureRequest {
   signature: string;
@@ -72,6 +73,25 @@ export class SignatureRequestController extends Controller {
         return this.errorResponse(
           `Invalid signature request status: ${signatureRequest.status}`,
         );
+    }
+  }
+
+  @Post("process")
+  @SuccessResponse(200, "Signature requests processing started")
+  public async processSignatureRequests(): Promise<{
+    success: boolean;
+    message: string;
+  }> {
+    try {
+      const processor = SignatureRequestProcessor.getInstance();
+      console.log("Processing pending requests");
+      await processor.processPendingRequests();
+      return this.successResponse("Signature requests processing started");
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "Unknown error";
+      return this.errorResponse(
+        `Failed to process signature requests: ${message}`,
+      );
     }
   }
 

--- a/src/graphql/scalars/ethBigInt.ts
+++ b/src/graphql/scalars/ethBigInt.ts
@@ -1,28 +1,37 @@
-import {GraphQLScalarType} from "graphql/type/index.js";
-import {Kind} from "graphql/language/index.js";
+import { GraphQLScalarType } from "graphql/type/index.js";
+import { Kind } from "graphql/language/index.js";
 
 export const EthBigInt = new GraphQLScalarType({
-    name: "EthBigInt",
-    description: "Handles uint256 bigint values stored in DB",
-    serialize(value: unknown): string {
-        // Check type of value
-        if (typeof value !== "bigint" && typeof value !== "number" && typeof value !== "string") {
-            throw new Error("EthBigInt can only serialize BigInt values");
-        }
-        return BigInt(value).toString(); // Value sent to client
-    },
-    parseValue(value: unknown): bigint {
-        // Check type of value  bigint | boolean | number | string
-        if (typeof value !== "string" && typeof value !== "bigint" && typeof value !== "number" && typeof value !== "boolean") {
-            throw new Error("EthBigInt can only parse string values");
-        }
-        return BigInt(value); // Value from client input variables
-    },
-    parseLiteral(ast): bigint {
-        // Check type of value
-        if (ast.kind !== Kind.STRING) {
-            throw new Error("ObjectIdScalar can only parse string values");
-        }
-        return BigInt(ast.value); // Value from client query
-    },
+  name: "EthBigInt",
+  description: "Handles uint256 bigint values stored in DB",
+  serialize(value: unknown): string {
+    // Check type of value
+    if (
+      typeof value !== "bigint" &&
+      typeof value !== "number" &&
+      typeof value !== "string"
+    ) {
+      throw new Error("EthBigInt can only serialize BigInt values");
+    }
+    return BigInt(value).toString(); // Value sent to client
+  },
+  parseValue(value: unknown): bigint {
+    // Check type of value  bigint | boolean | number | string
+    if (
+      typeof value !== "string" &&
+      typeof value !== "bigint" &&
+      typeof value !== "number" &&
+      typeof value !== "boolean"
+    ) {
+      throw new Error("EthBigInt can only parse string values");
+    }
+    return BigInt(value); // Value from client input variables
+  },
+  parseLiteral(ast): bigint {
+    // Check type of value
+    if (ast.kind !== Kind.STRING) {
+      throw new Error("ObjectIdScalar can only parse string values");
+    }
+    return BigInt(ast.value); // Value from client query
+  },
 });

--- a/src/graphql/schemas/args/signatureRequestArgs.ts
+++ b/src/graphql/schemas/args/signatureRequestArgs.ts
@@ -1,0 +1,32 @@
+import { ArgsType, Field, InputType } from "type-graphql";
+
+import { BasicSignatureRequestWhereInput } from "../inputs/signatureRequestInput.js";
+import type { OrderOptions } from "../inputs/orderOptions.js";
+import { SignatureRequest } from "../typeDefs/signatureRequestTypeDefs.js";
+import { SignatureRequestSortOptions } from "../inputs/sortOptions.js";
+
+import { withPagination } from "./baseArgs.js";
+
+@InputType()
+export class SignatureRequestWhereInput extends BasicSignatureRequestWhereInput {}
+
+@InputType()
+export class SignatureRequestFetchInput
+  implements OrderOptions<SignatureRequest>
+{
+  @Field(() => SignatureRequestSortOptions, { nullable: true })
+  by?: SignatureRequestSortOptions;
+}
+
+@ArgsType()
+class SignatureRequestArgs {
+  @Field(() => SignatureRequestWhereInput, { nullable: true })
+  where?: SignatureRequestWhereInput;
+  @Field(() => SignatureRequestFetchInput, { nullable: true })
+  sort?: SignatureRequestFetchInput;
+}
+
+@ArgsType()
+export class GetSignatureRequestArgs extends withPagination(
+  SignatureRequestArgs,
+) {}

--- a/src/graphql/schemas/inputs/searchOptions.ts
+++ b/src/graphql/schemas/inputs/searchOptions.ts
@@ -1,5 +1,9 @@
 import { Field, InputType, Int } from "type-graphql";
 import { GraphQLBigInt, GraphQLUUID } from "graphql-scalars";
+import {
+  SignatureRequestPurpose,
+  SignatureRequestStatus,
+} from "../typeDefs/signatureRequestTypeDefs.js";
 
 @InputType()
 export class BooleanSearchOptions {
@@ -95,4 +99,16 @@ export class NumberArraySearchOptions {
     description: "Array of numbers",
   })
   overlaps?: bigint[];
+}
+
+@InputType()
+export class SignatureRequestPurposeSearchOptions {
+  @Field(() => SignatureRequestPurpose, { nullable: true })
+  eq?: SignatureRequestPurpose;
+}
+
+@InputType()
+export class SignatureRequestStatusSearchOptions {
+  @Field(() => SignatureRequestStatus, { nullable: true })
+  eq?: SignatureRequestStatus;
 }

--- a/src/graphql/schemas/inputs/signatureRequestInput.ts
+++ b/src/graphql/schemas/inputs/signatureRequestInput.ts
@@ -1,0 +1,34 @@
+import { Field, InputType } from "type-graphql";
+
+import { SignatureRequest } from "../typeDefs/signatureRequestTypeDefs.js";
+
+import type { WhereOptions } from "./whereOptions.js";
+import {
+  BigIntSearchOptions,
+  SignatureRequestPurposeSearchOptions,
+  SignatureRequestStatusSearchOptions,
+  StringSearchOptions,
+} from "./searchOptions.js";
+
+@InputType()
+export class BasicSignatureRequestWhereInput
+  implements WhereOptions<SignatureRequest>
+{
+  @Field(() => StringSearchOptions, { nullable: true })
+  safe_address?: StringSearchOptions;
+
+  @Field(() => StringSearchOptions, { nullable: true })
+  message_hash?: StringSearchOptions;
+
+  @Field(() => BigIntSearchOptions, { nullable: true })
+  timestamp?: BigIntSearchOptions;
+
+  @Field(() => BigIntSearchOptions, { nullable: true })
+  chain_id?: BigIntSearchOptions;
+
+  @Field(() => SignatureRequestPurposeSearchOptions, { nullable: true })
+  purpose?: SignatureRequestPurposeSearchOptions;
+
+  @Field(() => SignatureRequestStatusSearchOptions, { nullable: true })
+  status?: SignatureRequestStatusSearchOptions;
+}

--- a/src/graphql/schemas/inputs/sortOptions.ts
+++ b/src/graphql/schemas/inputs/sortOptions.ts
@@ -10,6 +10,7 @@ import { Order } from "../typeDefs/orderTypeDefs.js";
 import { Sale } from "../typeDefs/salesTypeDefs.js";
 import { Hyperboard } from "../typeDefs/hyperboardTypeDefs.js";
 import { Blueprint } from "../typeDefs/blueprintTypeDefs.js";
+import { SignatureRequest } from "../typeDefs/signatureRequestTypeDefs.js";
 
 export type SortOptions<T extends object> = {
   [P in keyof T]: SortOrder | null;
@@ -219,4 +220,21 @@ export class HyperboardSortOptions implements SortOptions<Hyperboard> {
   admin_id?: SortOrder;
   @Field(() => SortOrder, { nullable: true })
   chainId?: SortOrder;
+}
+
+@InputType()
+export class SignatureRequestSortOptions
+  implements SortOptions<SignatureRequest>
+{
+  @Field(() => SortOrder, { nullable: true })
+  safe_address?: SortOrder;
+
+  @Field(() => SortOrder, { nullable: true })
+  message_hash?: SortOrder;
+
+  @Field(() => SortOrder, { nullable: true })
+  timestamp?: SortOrder;
+
+  @Field(() => SortOrder, { nullable: true })
+  purpose?: SortOrder;
 }

--- a/src/graphql/schemas/inputs/whereOptions.ts
+++ b/src/graphql/schemas/inputs/whereOptions.ts
@@ -10,6 +10,7 @@ import type { BasicContractWhereInput } from "./contractInput.js";
 import type { BasicFractionWhereInput } from "./fractionInput.js";
 import type { BasicMetadataWhereInput } from "./metadataInput.js";
 import type { BasicHypercertWhereArgs } from "./hypercertsInput.js";
+import type { BasicSignatureRequestWhereInput } from "./signatureRequestInput.js";
 
 export type WhereOptions<T extends object> = {
   [P in keyof T]:
@@ -23,5 +24,6 @@ export type WhereOptions<T extends object> = {
     | BasicHypercertWhereArgs
     | BasicContractWhereInput
     | BasicFractionWhereInput
+    | BasicSignatureRequestWhereInput
     | null;
 };

--- a/src/graphql/schemas/resolvers/baseTypes.ts
+++ b/src/graphql/schemas/resolvers/baseTypes.ts
@@ -12,6 +12,7 @@ import { GetHypercertsArgs } from "../args/hypercertsArgs.js";
 import { GetSalesArgs } from "../args/salesArgs.js";
 import { GetUserArgs } from "../args/userArgs.js";
 import { GetBlueprintArgs } from "../args/blueprintArgs.js";
+import { GetSignatureRequestArgs } from "../args/signatureRequestArgs.js";
 
 export function DataResponse<TItem extends object>(
   TItemClass: ClassType<TItem>,
@@ -369,6 +370,38 @@ export function createBaseResolver<T extends ClassType>(
         ...item,
         attestation: decodedData,
       };
+    }
+
+    getSignatureRequests(
+      args: GetSignatureRequestArgs,
+      single: boolean = false,
+    ) {
+      console.debug(
+        `[${entityFieldName}Resolver::getSignatureRequests] Fetching signature requests`,
+      );
+
+      try {
+        const queries = this.supabaseDataService.getSignatureRequests(args);
+        if (single) {
+          return queries.data.executeTakeFirst();
+        }
+
+        return this.supabaseDataService.db
+          .transaction()
+          .execute(async (transaction) => {
+            const dataRes = await transaction.executeQuery(queries.data);
+            const countRes = await transaction.executeQuery(queries.count);
+            return {
+              data: dataRes.rows,
+              count: countRes.rows[0].count,
+            };
+          });
+      } catch (e) {
+        const error = e as Error;
+        throw new Error(
+          `[${entityFieldName}Resolver::getSignatureRequests] Error fetching signature requests: ${error.message}`,
+        );
+      }
     }
   }
 

--- a/src/graphql/schemas/resolvers/composed.ts
+++ b/src/graphql/schemas/resolvers/composed.ts
@@ -10,6 +10,7 @@ import { AllowlistRecordResolver } from "./allowlistRecordResolver.js";
 import { SalesResolver } from "./salesResolver.js";
 import { UserResolver } from "./userResolver.js";
 import { BlueprintResolver } from "./blueprintResolver.js";
+import { SignatureRequestResolver } from "./signatureRequestResolver.js";
 
 export const resolvers = [
   ContractResolver,
@@ -24,4 +25,5 @@ export const resolvers = [
   SalesResolver,
   UserResolver,
   BlueprintResolver,
+  SignatureRequestResolver,
 ] as const;

--- a/src/graphql/schemas/resolvers/signatureRequestResolver.ts
+++ b/src/graphql/schemas/resolvers/signatureRequestResolver.ts
@@ -1,0 +1,35 @@
+import {
+  Args,
+  ObjectType,
+  Query,
+  Resolver,
+  FieldResolver,
+  Root,
+} from "type-graphql";
+
+import { SignatureRequest } from "../typeDefs/signatureRequestTypeDefs.js";
+import { GetSignatureRequestArgs } from "../args/signatureRequestArgs.js";
+
+import { createBaseResolver, DataResponse } from "./baseTypes.js";
+
+@ObjectType()
+class GetSignatureRequestResponse extends DataResponse(SignatureRequest) {}
+
+const SignatureRequestBaseResolver = createBaseResolver("signatureRequest");
+
+@Resolver(() => SignatureRequest)
+class SignatureRequestResolver extends SignatureRequestBaseResolver {
+  @Query(() => GetSignatureRequestResponse)
+  async signatureRequests(@Args() args: GetSignatureRequestArgs) {
+    return await this.getSignatureRequests(args);
+  }
+
+  @FieldResolver(() => String)
+  message(@Root() signatureRequest: SignatureRequest): string {
+    return typeof signatureRequest.message === "object"
+      ? JSON.stringify(signatureRequest.message)
+      : signatureRequest.message || "could not parse message";
+  }
+}
+
+export { SignatureRequestResolver };

--- a/src/graphql/schemas/resolvers/userResolver.ts
+++ b/src/graphql/schemas/resolvers/userResolver.ts
@@ -1,7 +1,17 @@
-import { Args, ObjectType, Query, Resolver } from "type-graphql";
-import { createBaseResolver, DataResponse } from "./baseTypes.js";
+import {
+  Args,
+  ObjectType,
+  Query,
+  Resolver,
+  FieldResolver,
+  Root,
+} from "type-graphql";
+
 import { User } from "../typeDefs/userTypeDefs.js";
 import { GetUserArgs } from "../args/userArgs.js";
+import { SignatureRequest } from "../typeDefs/signatureRequestTypeDefs.js";
+
+import { createBaseResolver, DataResponse } from "./baseTypes.js";
 
 @ObjectType()
 export default class GetUsersResponse extends DataResponse(User) {}
@@ -13,6 +23,27 @@ class UserResolver extends UserBaseResolver {
   @Query(() => GetUsersResponse)
   async users(@Args() args: GetUserArgs) {
     return this.getUsers(args);
+  }
+
+  @FieldResolver(() => [SignatureRequest])
+  async signature_requests(@Root() user: User) {
+    if (!user.address) {
+      return [];
+    }
+
+    try {
+      const queryResult = await this.getSignatureRequests({
+        where: {
+          safe_address: {
+            eq: user.address,
+          },
+        },
+      });
+      return queryResult.data || [];
+    } catch (error) {
+      console.error("Error fetching signature requests:", error);
+      return [];
+    }
   }
 }
 

--- a/src/graphql/schemas/typeDefs/signatureRequestTypeDefs.ts
+++ b/src/graphql/schemas/typeDefs/signatureRequestTypeDefs.ts
@@ -1,0 +1,66 @@
+import { Field, ObjectType, registerEnumType } from "type-graphql";
+
+import { EthBigInt } from "../../scalars/ethBigInt.js";
+
+enum SignatureRequestPurpose {
+  UPDATE_USER_DATA = "update_user_data",
+}
+
+enum SignatureRequestStatus {
+  PENDING = "pending",
+  EXECUTED = "executed",
+  CANCELED = "canceled",
+}
+
+registerEnumType(SignatureRequestPurpose, {
+  name: "SignatureRequestPurpose",
+  description: "Purpose of the signature request",
+});
+
+registerEnumType(SignatureRequestStatus, {
+  name: "SignatureRequestStatus",
+  description: "Status of the signature request",
+});
+
+@ObjectType({
+  description: "Pending signature request for a user",
+  simpleResolvers: true,
+})
+class SignatureRequest {
+  @Field({
+    description: "The safe address of the user who needs to sign",
+  })
+  safe_address?: string;
+
+  @Field({
+    description: "The hash of the Safe message (not the message to be signed)",
+  })
+  message_hash?: string;
+
+  @Field(() => String, {
+    description: "The message data in JSON format",
+  })
+  message?: string;
+
+  @Field(() => EthBigInt, {
+    description: "Timestamp of when the signature request was created",
+  })
+  timestamp?: bigint | number | string;
+
+  @Field(() => SignatureRequestPurpose, {
+    description: "The purpose of the signature request",
+  })
+  purpose?: SignatureRequestPurpose;
+
+  @Field(() => SignatureRequestStatus, {
+    description: "The status of the signature request",
+  })
+  status?: SignatureRequestStatus;
+
+  @Field(() => EthBigInt, {
+    description: "The chain ID of the signature request",
+  })
+  chain_id?: bigint | number | string;
+}
+
+export { SignatureRequest, SignatureRequestPurpose, SignatureRequestStatus };

--- a/src/graphql/schemas/typeDefs/userTypeDefs.ts
+++ b/src/graphql/schemas/typeDefs/userTypeDefs.ts
@@ -1,6 +1,8 @@
 import { Field, ObjectType } from "type-graphql";
 import { EthBigInt } from "../../scalars/ethBigInt.js";
 
+import { SignatureRequest } from "./signatureRequestTypeDefs.js";
+
 @ObjectType()
 class User {
   @Field({ description: "The address of the user" })
@@ -17,6 +19,12 @@ class User {
     nullable: true,
   })
   chain_id?: bigint | number | string;
+
+  @Field(() => [SignatureRequest], {
+    nullable: true,
+    description: "Pending signature requests for the user",
+  })
+  signature_requests?: SignatureRequest[];
 }
 
 export { User };

--- a/src/lib/safe-signature-verification/SafeSignatureVerifier.ts
+++ b/src/lib/safe-signature-verification/SafeSignatureVerifier.ts
@@ -1,0 +1,47 @@
+import { getAddress, hashTypedData, type HashTypedDataParameters } from "viem";
+import Safe from "@safe-global/protocol-kit";
+
+import { getRpcUrl } from "../../utils/getRpcUrl.js";
+
+export default abstract class SafeSignatureVerifier {
+  protected chainId: number;
+  protected safeAddress: `0x${string}`;
+  protected rpcUrl: string;
+
+  constructor(chainId: number, safeAddress: `0x${string}`) {
+    const rpcUrl = getRpcUrl(chainId);
+
+    if (!rpcUrl) {
+      throw new Error(`Unsupported chain ID: ${chainId}`);
+    }
+    this.chainId = chainId;
+    this.safeAddress = getAddress(safeAddress);
+    this.rpcUrl = rpcUrl;
+  }
+
+  hashTypedData() {
+    const parameters = this.buildTypedData();
+
+    return hashTypedData({
+      domain: {
+        name: "Hypercerts",
+        version: "1",
+        chainId: this.chainId,
+        verifyingContract: this.safeAddress,
+      },
+      ...parameters,
+    });
+  }
+
+  abstract buildTypedData(): Omit<HashTypedDataParameters, "domain">;
+
+  async verify(signature: string): Promise<boolean> {
+    const safe = await Safe.default.init({
+      provider: this.rpcUrl,
+      safeAddress: this.safeAddress,
+    });
+
+    const protocolKit = await safe.connect({});
+    return protocolKit.isValidSignature(this.hashTypedData(), signature);
+  }
+}

--- a/src/lib/safe-signature-verification/UserUpsertSignatureVerifier.ts
+++ b/src/lib/safe-signature-verification/UserUpsertSignatureVerifier.ts
@@ -1,0 +1,34 @@
+import { MultisigUserUpdateMessage } from "../users/schemas.js";
+
+import SafeSignatureVerifier from "./SafeSignatureVerifier.js";
+
+export default class UserUpsertSignatureVerifier extends SafeSignatureVerifier {
+  private message: MultisigUserUpdateMessage;
+
+  constructor(
+    chainId: number,
+    safeAddress: `0x${string}`,
+    message: MultisigUserUpdateMessage,
+  ) {
+    super(chainId, safeAddress);
+    this.message = message;
+  }
+
+  buildTypedData() {
+    return {
+      types: {
+        Metadata: [{ name: "timestamp", type: "uint256" }],
+        User: [
+          { name: "displayName", type: "string" },
+          { name: "avatar", type: "string" },
+        ],
+        UserUpdateRequest: [
+          { name: "metadata", type: "Metadata" },
+          { name: "user", type: "User" },
+        ],
+      },
+      primaryType: "UserUpdateRequest",
+      message: this.message,
+    };
+  }
+}

--- a/src/lib/users/EOAUpsertStrategy.ts
+++ b/src/lib/users/EOAUpsertStrategy.ts
@@ -1,0 +1,74 @@
+import { verifyAuthSignedData } from "../../utils/verifyAuthSignedData.js";
+import { SupabaseDataService } from "../../services/SupabaseDataService.js";
+import type { AddOrUpdateUserResponse } from "../../types/api.js";
+
+import type { EOAUpdateRequest } from "./schemas.js";
+import type { UserUpsertStrategy } from "./UserUpsertStrategy.js";
+import { UserUpsertError } from "./errors.js";
+
+export default class EOAUpdateStrategy implements UserUpsertStrategy {
+  private readonly dataService: SupabaseDataService;
+
+  constructor(
+    private readonly address: string,
+    private readonly request: EOAUpdateRequest,
+  ) {
+    this.dataService = new SupabaseDataService();
+  }
+
+  async execute(): Promise<AddOrUpdateUserResponse> {
+    await this.throwIfInvalidSignature();
+    const user = await this.upsertUser();
+    return {
+      success: true,
+      message: "User added or updated successfully",
+      data: user,
+    };
+  }
+
+  private async upsertUser(): Promise<{ address: string }> {
+    try {
+      const users = await this.dataService.upsertUsers([
+        {
+          address: this.address,
+          display_name: this.request.display_name,
+          avatar: this.request.avatar,
+          chain_id: this.request.chain_id,
+        },
+      ]);
+
+      if (!users.length) {
+        throw new UserUpsertError(500, "Error adding or updating user");
+      }
+      return users[0];
+    } catch (error) {
+      console.error(error);
+      throw new UserUpsertError(500, "Error adding or updating user");
+    }
+  }
+
+  private async throwIfInvalidSignature(): Promise<void> {
+    const isValidSignature = await verifyAuthSignedData({
+      address: this.address as `0x${string}`,
+      types: {
+        User: [
+          { name: "displayName", type: "string" },
+          { name: "avatar", type: "string" },
+        ],
+        UserUpdateRequest: [{ name: "user", type: "User" }],
+      },
+      primaryType: "UserUpdateRequest",
+      signature: this.request.signature as `0x${string}`,
+      message: {
+        user: {
+          displayName: this.request.display_name || "",
+          avatar: this.request.avatar || "",
+        },
+      },
+      requiredChainId: this.request.chain_id,
+    });
+    if (!isValidSignature) {
+      throw new UserUpsertError(401, "Invalid signature");
+    }
+  }
+}

--- a/src/lib/users/MultisigUpsertStrategy.ts
+++ b/src/lib/users/MultisigUpsertStrategy.ts
@@ -1,0 +1,82 @@
+import { z } from "zod";
+import SafeApiKit, { type SafeApiKitConfig } from "@safe-global/api-kit";
+
+import { SignatureRequestPurpose } from "../../graphql/schemas/typeDefs/signatureRequestTypeDefs.js";
+import { SupabaseDataService } from "../../services/SupabaseDataService.js";
+import { AddOrUpdateUserResponse } from "../../types/api.js";
+import { isTypedMessage } from "../../utils/signatures.js";
+
+import type { UserUpsertStrategy } from "./UserUpsertStrategy.js";
+import type { MultisigUpdateRequest } from "./schemas.js";
+import { UserUpsertError } from "./errors.js";
+
+const MESSAGE_SCHEMA = z.object({
+  metadata: z.object({
+    timestamp: z
+      .number()
+      .int()
+      .refine(
+        (val) => String(val).length === 10,
+        "Timestamp must be a Unix timestamp in seconds (10 digits)",
+      ),
+  }),
+  user: z.object({
+    displayName: z.string().optional(),
+    avatar: z.string().optional(),
+  }),
+});
+
+export default class MultisigUpdateStrategy implements UserUpsertStrategy {
+  private readonly dataService: SupabaseDataService;
+  // Safe SDKs only support CommonJS, so TS interprets `SafeApiKit` as a namespace.
+  // https://docs.safe.global/sdk/overview
+  // Hence the explicit `default` here and on the instantiation further down.
+  private readonly safeApiKit: SafeApiKit.default;
+
+  constructor(
+    private readonly address: string,
+    private readonly request: MultisigUpdateRequest,
+  ) {
+    const config: SafeApiKitConfig = {
+      chainId: BigInt(request.chain_id),
+    };
+    this.safeApiKit = new SafeApiKit.default(config);
+    this.dataService = new SupabaseDataService();
+  }
+
+  // We could check if it's a 1 of 1 and execute right away
+  async execute(): Promise<AddOrUpdateUserResponse> {
+    const { message } = await this.safeApiKit.getMessage(
+      this.request.messageHash,
+    );
+
+    if (!isTypedMessage(message)) {
+      throw new UserUpsertError(
+        500,
+        "Safe message is not a typed user update message.",
+      );
+    }
+    const parseResult = MESSAGE_SCHEMA.safeParse(message.message);
+    if (!parseResult.success) {
+      throw new UserUpsertError(
+        400,
+        parseResult.error.errors.map((e) => e.message).join("; "),
+      );
+    }
+    console.log("Creating signature request for", parseResult);
+    await this.dataService.addSignatureRequest({
+      chain_id: this.request.chain_id,
+      safe_address: this.address,
+      message_hash: this.request.messageHash,
+      message: parseResult.data,
+      purpose: SignatureRequestPurpose.UPDATE_USER_DATA,
+      timestamp: parseResult.data.metadata.timestamp,
+    });
+
+    return {
+      success: true,
+      message: "Signature request created successfully",
+      data: null,
+    };
+  }
+}

--- a/src/lib/users/UserUpsertStrategy.ts
+++ b/src/lib/users/UserUpsertStrategy.ts
@@ -1,0 +1,23 @@
+import { AddOrUpdateUserResponse } from "../../types/api.js";
+
+import MultisigUpsertStrategy from "./MultisigUpsertStrategy.js";
+import EOAUpsertStrategy from "./EOAUpsertStrategy.js";
+import { EOAUpdateRequest, MultisigUpdateRequest } from "./schemas.js";
+
+export interface UserUpsertStrategy {
+  execute(): Promise<AddOrUpdateUserResponse>;
+}
+
+export function createStrategy(
+  address: string,
+  request: MultisigUpdateRequest | EOAUpdateRequest,
+): UserUpsertStrategy {
+  switch (request.type) {
+    case "eoa":
+      return new EOAUpsertStrategy(address, request);
+    case "multisig":
+      return new MultisigUpsertStrategy(address, request);
+    default:
+      throw new Error("Invalid user update request type");
+  }
+}

--- a/src/lib/users/errors.ts
+++ b/src/lib/users/errors.ts
@@ -1,0 +1,11 @@
+import { AddOrUpdateUserResponse } from "../../types/api.js";
+
+export class UserUpsertError extends Error {
+  code: number;
+  public errors: AddOrUpdateUserResponse["errors"];
+  constructor(code: number, message: string) {
+    super(message);
+    this.name = "UserUpdateError";
+    this.code = code;
+  }
+}

--- a/src/lib/users/schemas.ts
+++ b/src/lib/users/schemas.ts
@@ -1,5 +1,21 @@
 import { z } from "zod";
 
+// This is the message schema that is signed by the multisig
+export const USER_UPDATE_MESSAGE_SCHEMA = z.object({
+  metadata: z.object({
+    timestamp: z.number(),
+  }),
+  user: z.object({
+    displayName: z.string().optional(),
+    avatar: z.string().optional(),
+  }),
+});
+
+export type MultisigUserUpdateMessage = z.infer<
+  typeof USER_UPDATE_MESSAGE_SCHEMA
+>;
+
+// API request schemas for user updates
 export const USER_UPDATE_REQUEST_BASE_SCHEMA = z.object({
   chain_id: z.number(),
 });

--- a/src/lib/users/schemas.ts
+++ b/src/lib/users/schemas.ts
@@ -1,0 +1,31 @@
+import { z } from "zod";
+
+export const USER_UPDATE_REQUEST_BASE_SCHEMA = z.object({
+  chain_id: z.number(),
+});
+
+export const EOA_UPDATE_REQUEST_SCHEMA = USER_UPDATE_REQUEST_BASE_SCHEMA.extend(
+  {
+    type: z.literal("eoa"),
+    display_name: z.string().optional(),
+    avatar: z.string().optional(),
+    signature: z.string(),
+  },
+);
+
+export const MULTISIG_UPDATE_REQUEST_SCHEMA =
+  USER_UPDATE_REQUEST_BASE_SCHEMA.extend({
+    type: z.literal("multisig"),
+    messageHash: z.string(),
+  });
+
+export const USER_UPDATE_REQUEST_SCHEMA = z.union([
+  EOA_UPDATE_REQUEST_SCHEMA,
+  MULTISIG_UPDATE_REQUEST_SCHEMA,
+]);
+
+export type EOAUpdateRequest = z.infer<typeof EOA_UPDATE_REQUEST_SCHEMA>;
+
+export type MultisigUpdateRequest = z.infer<
+  typeof MULTISIG_UPDATE_REQUEST_SCHEMA
+>;

--- a/src/services/SafeApiQueue.ts
+++ b/src/services/SafeApiQueue.ts
@@ -1,0 +1,95 @@
+import { ISafeApiCommand } from "../types/safe-signatures.js";
+
+interface QueueConfig {
+  maxConcurrent: number;
+  rateLimit: number;
+}
+
+export class SafeApiQueue {
+  private static instance: SafeApiQueue;
+  private queue: Map<string, ISafeApiCommand> = new Map();
+  private processing = false;
+  private activeCount = 0;
+  private tokens: number;
+  private lastRefill: number = Date.now();
+
+  constructor(private config: QueueConfig) {
+    this.tokens = config.rateLimit;
+  }
+
+  static getInstance(): SafeApiQueue {
+    if (!SafeApiQueue.instance) {
+      SafeApiQueue.instance = new SafeApiQueue({
+        maxConcurrent: 5,
+        rateLimit: 5,
+      });
+    }
+    return SafeApiQueue.instance;
+  }
+
+  addCommand(command: ISafeApiCommand): void {
+    if (!this.hasCommand(command)) {
+      this.queue.set(command.getId(), command);
+      this.startProcessing();
+    }
+  }
+
+  hasCommand(command: ISafeApiCommand): boolean {
+    return this.queue.has(command.getId());
+  }
+
+  private async startProcessing(): Promise<void> {
+    if (this.processing) return;
+    this.processing = true;
+
+    while (this.queue.size > 0 || this.activeCount > 0) {
+      this.refillTokens();
+      await this.processAvailableCommands();
+      // To prevent CPU spinning
+      await new Promise((resolve) => setTimeout(resolve, 50));
+    }
+
+    this.processing = false;
+  }
+
+  private async processAvailableCommands(): Promise<void> {
+    while (
+      this.queue.size > 0 &&
+      this.tokens > 0 &&
+      this.activeCount < this.config.maxConcurrent
+    ) {
+      const command = this.queue.values().next().value;
+      this.queue.delete(command.getId());
+
+      this.tokens--;
+      this.activeCount++;
+
+      this.executeCommand(command).finally(() => {
+        this.activeCount--;
+      });
+    }
+  }
+
+  private refillTokens(): void {
+    const now = Date.now();
+    const timePassed = now - this.lastRefill;
+    const newTokens = Math.floor((timePassed / 1000) * this.config.rateLimit);
+
+    this.tokens = Math.min(this.config.rateLimit, this.tokens + newTokens);
+    this.lastRefill = now;
+  }
+
+  private async executeCommand(command: ISafeApiCommand): Promise<void> {
+    try {
+      console.log(`Executing command: ${command.getId()}`);
+      await command.execute();
+    } catch (error) {
+      const errorMessage =
+        error instanceof Error ? error.message : "Unknown error";
+      console.error(
+        `Failed to execute command: ${command.getId()}`,
+        errorMessage,
+      );
+    }
+  }
+}

--- a/src/services/SignatureRequestProcessor.ts
+++ b/src/services/SignatureRequestProcessor.ts
@@ -1,0 +1,55 @@
+import { SignatureRequestStatus } from "../graphql/schemas/typeDefs/signatureRequestTypeDefs.js";
+import { Database } from "../types/supabaseData.js";
+import { getCommand } from "../commands/CommandFactory.js";
+
+import { SupabaseDataService } from "./SupabaseDataService.js";
+import { SafeApiQueue } from "./SafeApiQueue.js";
+
+type SignatureRequest =
+  Database["public"]["Tables"]["signature_requests"]["Row"];
+
+export class SignatureRequestProcessor {
+  private static instance: SignatureRequestProcessor;
+
+  private readonly dataService: SupabaseDataService;
+  private readonly queue: SafeApiQueue;
+
+  constructor() {
+    this.dataService = new SupabaseDataService();
+    this.queue = SafeApiQueue.getInstance();
+  }
+
+  async processPendingRequests(): Promise<void> {
+    const pendingRequests = await this.getPendingRequests();
+
+    console.log(`Found ${pendingRequests.length} pending requests`);
+
+    for (const request of pendingRequests) {
+      const command = getCommand(request);
+      if (this.queue.hasCommand(command)) {
+        continue;
+      }
+      this.queue.addCommand(command);
+    }
+  }
+
+  private async getPendingRequests(): Promise<SignatureRequest[]> {
+    const response = await this.dataService.getSignatureRequests({
+      where: {
+        status: { eq: SignatureRequestStatus.PENDING },
+      },
+    });
+
+    return this.dataService.db.transaction().execute(async (transaction) => {
+      const dataRes = await transaction.executeQuery(response.data);
+      return dataRes.rows as SignatureRequest[];
+    });
+  }
+
+  static getInstance(): SignatureRequestProcessor {
+    if (!SignatureRequestProcessor.instance) {
+      SignatureRequestProcessor.instance = new SignatureRequestProcessor();
+    }
+    return SignatureRequestProcessor.instance;
+  }
+}

--- a/src/services/SupabaseDataService.ts
+++ b/src/services/SupabaseDataService.ts
@@ -673,6 +673,28 @@ export class SupabaseDataService extends BaseSupabaseService<KyselyDataDatabase>
       .execute();
   }
 
+  async getSignatureRequest(safe_address: string, message_hash: string) {
+    return this.db
+      .selectFrom("signature_requests")
+      .selectAll()
+      .where("safe_address", "=", safe_address)
+      .where("message_hash", "=", message_hash)
+      .executeTakeFirst();
+  }
+
+  async updateSignatureRequestStatus(
+    safe_address: string,
+    message_hash: string,
+    status: DataDatabase["public"]["Enums"]["signature_request_status_enum"],
+  ) {
+    return this.db
+      .updateTable("signature_requests")
+      .set({ status })
+      .where("safe_address", "=", safe_address)
+      .where("message_hash", "=", message_hash)
+      .execute();
+  }
+
   getSignatureRequests(args: GetSignatureRequestArgs) {
     return {
       data: this.handleGetData("signature_requests", args),

--- a/src/services/SupabaseDataService.ts
+++ b/src/services/SupabaseDataService.ts
@@ -662,6 +662,16 @@ export class SupabaseDataService extends BaseSupabaseService<KyselyDataDatabase>
       .execute();
   }
 
+  async addSignatureRequest(
+    request: DataDatabase["public"]["Tables"]["signature_requests"]["Insert"]
+  ) {
+    return this.db
+      .insertInto("signature_requests")
+      .values(request)
+      .returning(["safe_address", "message_hash"])
+      .execute();
+  }
+
   getDataQuery<
     DB extends KyselyDataDatabase,
     T extends keyof DB & string,

--- a/src/services/SupabaseDataService.ts
+++ b/src/services/SupabaseDataService.ts
@@ -21,6 +21,7 @@ import { BaseSupabaseService } from "./BaseSupabaseService.js";
 import { jsonArrayFrom } from "kysely/helpers/postgres";
 import { GetBlueprintArgs } from "../graphql/schemas/args/blueprintArgs.js";
 import { sql } from "kysely";
+import { GetSignatureRequestArgs } from "../graphql/schemas/args/signatureRequestArgs.js";
 
 @singleton()
 export class SupabaseDataService extends BaseSupabaseService<KyselyDataDatabase> {
@@ -663,13 +664,20 @@ export class SupabaseDataService extends BaseSupabaseService<KyselyDataDatabase>
   }
 
   async addSignatureRequest(
-    request: DataDatabase["public"]["Tables"]["signature_requests"]["Insert"]
+    request: DataDatabase["public"]["Tables"]["signature_requests"]["Insert"],
   ) {
     return this.db
       .insertInto("signature_requests")
       .values(request)
       .returning(["safe_address", "message_hash"])
       .execute();
+  }
+
+  getSignatureRequests(args: GetSignatureRequestArgs) {
+    return {
+      data: this.handleGetData("signature_requests", args),
+      count: this.handleGetCount("signature_requests", args),
+    };
   }
 
   getDataQuery<
@@ -687,6 +695,8 @@ export class SupabaseDataService extends BaseSupabaseService<KyselyDataDatabase>
         return this.db.selectFrom("marketplace_orders").selectAll();
       case "users":
         return this.db.selectFrom("users").selectAll();
+      case "signature_requests":
+        return this.db.selectFrom("signature_requests").selectAll();
       default:
         throw new Error(`Table ${tableName.toString()} not found`);
     }
@@ -714,6 +724,12 @@ export class SupabaseDataService extends BaseSupabaseService<KyselyDataDatabase>
       case "marketplace_orders":
         return this.db
           .selectFrom("marketplace_orders")
+          .select((expressionBuilder) => {
+            return expressionBuilder.fn.countAll().as("count");
+          });
+      case "signature_requests":
+        return this.db
+          .selectFrom("signature_requests")
           .select((expressionBuilder) => {
             return expressionBuilder.fn.countAll().as("count");
           });

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -1,5 +1,11 @@
 import type { HypercertMetadata } from "@hypercerts-org/sdk";
 
+/*
+ * The types in this file somewhat replicate the zod schemas we use in our controllers.
+ * Currently tsoa doesn't work with zod inferred types.
+ * See https://github.com/lukeautry/tsoa/issues/1256.
+ */
+
 /**
  * Interface for storing metadata on IPFS.
  */

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -76,13 +76,25 @@ export type ValidationResponse = ApiResponse<ValidationResult>;
 /**
  * Interface for a user add or update request.
  */
-
-export interface AddOrUpdateUserRequest {
-  display_name: string;
-  avatar: string;
-  signature: string;
+interface BaseUserUpsertRequest {
   chain_id: number;
 }
+
+interface EOAUserUpsertRequest extends BaseUserUpsertRequest {
+  type: "eoa";
+  display_name?: string;
+  avatar?: string;
+  signature: string;
+}
+
+interface MultisigUserUpsertRequest extends BaseUserUpsertRequest {
+  type: "multisig";
+  messageHash: string;
+}
+
+export type AddOrUpdateUserRequest =
+  | EOAUserUpsertRequest
+  | MultisigUserUpsertRequest;
 
 export type AddOrUpdateUserResponse = ApiResponse<{ address: string } | null>;
 

--- a/src/types/safe-signatures.ts
+++ b/src/types/safe-signatures.ts
@@ -1,0 +1,4 @@
+export interface ISafeApiCommand {
+  execute(): Promise<void>;
+  getId(): string;
+}

--- a/src/types/supabaseData.ts
+++ b/src/types/supabaseData.ts
@@ -592,6 +592,36 @@ export type Database = {
         };
         Relationships: [];
       };
+      signature_requests: {
+        Row: {
+          chain_id: number;
+          message: Json;
+          message_hash: string;
+          purpose: Database["public"]["Enums"]["signature_request_purpose_enum"];
+          safe_address: string;
+          status: Database["public"]["Enums"]["signature_request_status_enum"];
+          timestamp: number;
+        };
+        Insert: {
+          chain_id: number;
+          message: Json;
+          message_hash: string;
+          purpose?: Database["public"]["Enums"]["signature_request_purpose_enum"];
+          safe_address: string;
+          status?: Database["public"]["Enums"]["signature_request_status_enum"];
+          timestamp?: number;
+        };
+        Update: {
+          chain_id?: number;
+          message?: Json;
+          message_hash?: string;
+          purpose?: Database["public"]["Enums"]["signature_request_purpose_enum"];
+          safe_address?: string;
+          status?: Database["public"]["Enums"]["signature_request_status_enum"];
+          timestamp?: number;
+        };
+        Relationships: [];
+      };
       users: {
         Row: {
           address: string;
@@ -698,7 +728,8 @@ export type Database = {
       };
     };
     Enums: {
-      [_ in never]: never;
+      signature_request_purpose_enum: "update_user_data";
+      signature_request_status_enum: "pending" | "executed" | "canceled";
     };
     CompositeTypes: {
       [_ in never]: never;

--- a/src/utils/getRpcUrl.ts
+++ b/src/utils/getRpcUrl.ts
@@ -119,7 +119,6 @@ const fallBackProvider = (chainId: number) => {
 };
 
 /* Returns a PublicClient instance for the configured network. */
-// @ts-expect-error viem typings
 export const getEvmClient = (chainId: number) =>
   createPublicClient({
     chain: selectedNetwork(chainId),

--- a/src/utils/signatures.ts
+++ b/src/utils/signatures.ts
@@ -1,0 +1,5 @@
+import type { EIP712TypedData } from "@safe-global/api-kit";
+
+export function isTypedMessage(message: unknown): message is EIP712TypedData {
+  return message !== null && typeof message === "object" && "domain" in message;
+}

--- a/src/utils/verifyAuthSignedData.ts
+++ b/src/utils/verifyAuthSignedData.ts
@@ -8,8 +8,6 @@ export const verifyAuthSignedData = async ({
   VerifyTypedDataParameters,
   "address" | "message" | "types" | "signature" | "primaryType"
 > & { requiredChainId: number }) => {
-  // TODO: If signature = 0x, call safe sdk to verify signature
-  // https://github.com/safe-global/safe-apps-sdk/blob/main/packages/safe-apps-sdk/src/safe/index.ts#L57
   const client = getEvmClient(requiredChainId);
   try {
     return await client.verifyTypedData({

--- a/supabase/migrations/20241216115256_create_signature_requests_table.sql
+++ b/supabase/migrations/20241216115256_create_signature_requests_table.sql
@@ -1,0 +1,14 @@
+create type signature_request_purpose_enum as enum ('update_user_data');
+
+create type signature_request_status_enum as enum ('pending', 'executed', 'canceled');
+
+create table public.signature_requests (
+    safe_address citext not null,
+    message_hash text not null,
+    chain_id numeric(78,0) not null,
+    timestamp numeric(78,0) not null default extract(epoch from now()),
+    message jsonb not null,
+    purpose signature_request_purpose_enum not null default 'update_user_data',
+    status signature_request_status_enum not null default 'pending',
+    constraint signature_requests_pkey primary key (chain_id, safe_address, message_hash)
+) tablespace pg_default;

--- a/test/safe-signatures/SafeApiQueue.test.ts
+++ b/test/safe-signatures/SafeApiQueue.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect, vi } from "vitest";
+import { SafeApiQueue } from "../../src/services/SafeApiQueue.js";
+import { ISafeApiCommand } from "../../src/types/safe-signatures.js";
+
+class MockCommand implements ISafeApiCommand {
+  constructor(
+    private safeAddress: string,
+    private messageHash: string,
+  ) {}
+
+  async execute(): Promise<void> {
+    return new Promise((resolve) => setTimeout(resolve, 100));
+  }
+
+  getId(): string {
+    return `${this.safeAddress}-${this.messageHash}`;
+  }
+}
+
+describe("SafeApiQueue", () => {
+  it("should not add duplicate commands", () => {
+    const queue = new SafeApiQueue({ maxConcurrent: 1, rateLimit: 1 });
+    const commands = Array.from(
+      { length: 10 },
+      (_, i) => new MockCommand("0x123", `hash${i}`),
+    );
+    commands.forEach((command) => queue.addCommand(command));
+    const duplicate = new MockCommand("0x123", "hash9");
+    const spy = vi.spyOn(duplicate, "execute");
+    queue.addCommand(duplicate);
+    expect(queue.hasCommand(duplicate)).toBe(true);
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it("should not exceed max concurrent executions", async () => {
+    const queue = new SafeApiQueue({ maxConcurrent: 5, rateLimit: 5 });
+    const commands = Array.from(
+      { length: 10 },
+      (_, i) => new MockCommand("0x123", `hash${i}`),
+    );
+
+    commands.forEach((command) => queue.addCommand(command));
+
+    // Mock the execute method to track execution
+    const executeSpies = commands.map((command) =>
+      vi.spyOn(command, "execute"),
+    );
+
+    // Wait for processing
+    await new Promise((resolve) => setTimeout(resolve, 2000));
+
+    // Check that no more than maxConcurrent commands were executed at once
+    const maxConcurrentExecutions = Math.max(
+      ...executeSpies.map((spy) => spy.mock.calls.length),
+    );
+
+    expect(maxConcurrentExecutions).toBeLessThanOrEqual(5);
+  });
+});

--- a/test/safe-signatures/SafeSignatureVerifier.test.ts
+++ b/test/safe-signatures/SafeSignatureVerifier.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect } from "vitest";
+import Verifier from "../../src/lib/safe-signature-verification/UserUpsertSignatureVerifier.js";
+
+// Testing hashing of typed data via UserUpsertSignatureVerifier
+describe("hashTypedMessage", () => {
+  it("should hash the typed message correctly", () => {
+    const verifier = new Verifier(
+      11155111,
+      "0x379756bB61A632Cd3C5C5Ce4F3768f4815feaCda",
+      {
+        metadata: {
+          timestamp: 1732812295136,
+        },
+        user: {
+          displayName: "test name",
+          avatar: "https://example.org/image",
+        },
+      },
+    );
+    expect(verifier.hashTypedData()).toBe(
+      "0x56b9d12b9b854c0b80f253af1686aa70b14a5bc55ca94f98db6a947bd7660d7a",
+    );
+  });
+
+  it("should throw with missing fields", () => {
+    expect(() => {
+      const verifier = new Verifier(
+        11155111,
+        "0x379756bB61A632Cd3C5C5Ce4F3768f4815feaCda",
+        {
+          metadata: {
+            timestamp: 1732812295136,
+          },
+          user: {},
+        },
+      );
+      verifier.hashTypedData();
+    }).toThrow();
+  });
+
+  it("should handle special characters", () => {
+    const verifier = new Verifier(
+      11155111,
+      "0x379756bB61A632Cd3C5C5Ce4F3768f4815feaCda",
+      {
+        metadata: {
+          timestamp: 1732812295136,
+        },
+        user: {
+          displayName: "Test with special chars: éèàù@#$%^&*()_+",
+          avatar: "",
+        },
+      },
+    );
+    expect(verifier.hashTypedData()).toBeDefined();
+  });
+
+  it("should handle large data", () => {
+    const largeMessage = "a".repeat(10000);
+    const verifier = new Verifier(
+      11155111,
+      "0x379756bB61A632Cd3C5C5Ce4F3768f4815feaCda",
+      {
+        metadata: {
+          timestamp: 1732812295136,
+        },
+        user: {
+          displayName: largeMessage,
+          avatar: "",
+        },
+      },
+    );
+    expect(verifier.hashTypedData()).toBeDefined();
+  });
+
+  it("should throw with invalid chain ID", () => {
+    expect(() => {
+      const verifier = new Verifier(
+        1,
+        "0x379756bB61A632Cd3C5C5Ce4F3768f4815feaCda",
+        {
+          metadata: {
+            timestamp: 1732812295136,
+          },
+          user: {
+            displayName: "test name",
+            avatar: "",
+          },
+        },
+      );
+      verifier.hashTypedData();
+    }).toThrow("Unsupported chain ID: 1");
+  });
+
+  it("should handle empty strings", () => {
+    const verifier = new Verifier(
+      11155111,
+      "0x379756bB61A632Cd3C5C5Ce4F3768f4815feaCda",
+      {
+        metadata: {
+          timestamp: 1732812295136,
+        },
+        user: {
+          displayName: "",
+          avatar: "",
+        },
+      },
+    );
+    expect(verifier.hashTypedData()).toBe(
+      "0xa0752bebdb2725e200a8f2ebb6ad12f35b2566710f18c51e625276b267f623b9",
+    );
+  });
+});


### PR DESCRIPTION
This PR adds support for using a Safe to make profile updates (display name and avatar image).

When the user sends a `POST` request to `/v1/users/<safe-address>` with the correct payload for Safe signature flows the user controller will write a signature request to the `signature_requests` table. 

The signers now need to asynchronously complete the signatures in the Safe app. When the threshold is met, a `POST` to `/v1/signature-requests/process` will now queue up all pending signature requests and verify the signatures behind the scenes. The request is non-blocking as it might take a long time to complete.

Each signature request will now compute the message hash for the data the user initially submitted, get the signatures for the specific message from the Safe API and validate them on-chain. 

1. If the validation completes successfully, the signature request will be marked `executed` and the requested profile change will be written to the database.
2. If the validation fails, the signature request will stay in status `pending` and retried when the endpoint is called again.

This PR also exposes signature requests via GraphQL and attaches all profile change signature requests to a user entity.

Example query:
```graphql
query UserQuery {
  signatureRequests(
    where: {status: {eq: PENDING}, purpose: {eq: UPDATE_USER_DATA}}
  ) {
    data {
      safe_address
      message_hash
      message
      status
    }
  }
  users {
    data {
      display_name
      signature_requests {
        message
        status
      }
    }
  }
}
```

I couldn't write tests for `SignatureRequestProcessor` due to `type-graphql` errors that pop up on tests. We need to fix those first and then I can ship tests for this and the controller classes as a fast-follow.