### PR TITLE
Set upload limit to 11MB

### DIFF
--- a/src/middleware/upload.ts
+++ b/src/middleware/upload.ts
@@ -26,7 +26,7 @@ export const validateFile = async (
   file: Express.Multer.File,
 ): Promise<void> => {
   // 1. Check file size
-  if (file.size > 10 * 1024 * 1024) {
+  if (file.size > 11 * 1024 * 1024) {
     throw new Error(FileValidationError.SIZE_EXCEEDED);
   }
 


### PR DESCRIPTION
At 10 osme files around 9.7 failed. This is the ducttape solution until we've resolved the issues