### PR TITLE
Attestation resolver with schemas

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -81,6 +81,9 @@ type Attestation {
   """Encoded data of the attestation"""
   data: JSON
 
+  """Schema related to the attestation"""
+  eas_schema: AttestationSchemaBaseType!
+
   """Hypercert related to the attestation"""
   hypercert: HypercertBaseType!
   id: ID!
@@ -99,9 +102,6 @@ type Attestation {
 
   """Unique identifier of the EAS schema used to create the attestation"""
   schema_uid: String
-
-  """Schema related to the attestation"""
-  supported_schemas: AttestationSchemaBaseType!
 
   """Unique identifier for the attestation on EAS"""
   uid: ID
@@ -203,13 +203,13 @@ input AttestationWhereInput {
   contract_address: StringSearchOptions
   creation_block_number: BigIntSearchOptions
   creation_block_timestamp: BigIntSearchOptions
+  eas_schema: BasicAttestationSchemaWhereInput
   hypercerts: BasicHypercertWhereArgs
   last_update_block_number: BigIntSearchOptions
   last_update_block_timestamp: BigIntSearchOptions
   metadata: BasicMetadataWhereInput
   recipient: StringSearchOptions
   resolver: StringSearchOptions
-  supported_schemas: BasicAttestationSchemaWhereInput
   token_id: StringSearchOptions
   uid: StringSearchOptions
 }

--- a/schema.graphql
+++ b/schema.graphql
@@ -82,7 +82,7 @@ type Attestation {
   data: JSON
 
   """Hypercert related to the attestation"""
-  hypercert: HypercertBaseType
+  hypercert: HypercertBaseType!
   id: ID!
 
   """Block number at which the attestation was last updated"""
@@ -98,10 +98,43 @@ type Attestation {
   resolver: String
 
   """Unique identifier of the EAS schema used to create the attestation"""
-  schema: String
+  schema_uid: String
 
-  """ID referencing the supported EAS schema in the database"""
-  supported_schemas_id: ID
+  """Schema related to the attestation"""
+  supported_schemas: AttestationSchemaBaseType!
+
+  """Unique identifier for the attestation on EAS"""
+  uid: ID
+}
+
+type AttestationBaseType {
+  """Address of the creator of the attestation"""
+  attester: String
+
+  """Block number at which the attestation was created"""
+  creation_block_number: EthBigInt
+
+  """Timestamp at which the attestation was created"""
+  creation_block_timestamp: EthBigInt
+
+  """Encoded data of the attestation"""
+  data: JSON
+  id: ID!
+
+  """Block number at which the attestation was last updated"""
+  last_update_block_number: EthBigInt
+
+  """Timestamp at which the attestation was last updated"""
+  last_update_block_timestamp: EthBigInt
+
+  """Address of the recipient of the attestation"""
+  recipient: String
+
+  """Address of the resolver contract for the attestation"""
+  resolver: String
+
+  """Unique identifier of the EAS schema used to create the attestation"""
+  schema_uid: String
 
   """Unique identifier for the attestation on EAS"""
   uid: ID
@@ -114,23 +147,42 @@ input AttestationFetchInput {
 """Supported EAS attestation schemas and their related records"""
 type AttestationSchema {
   """Chain ID of the chains where the attestation schema is supported"""
-  chain_id: EthBigInt
+  chain_id: EthBigInt!
   id: ID!
 
   """List of attestations related to the attestation schema"""
-  records: [Attestation!]
+  records: [AttestationBaseType!]!
 
   """Address of the resolver contract for the attestation schema"""
-  resolver: String
+  resolver: String!
 
   """Whether the attestation schema is revocable"""
-  revocable: Boolean
+  revocable: Boolean!
 
   """String representation of the attestation schema"""
-  schema: String
+  schema: String!
 
   """Unique identifier for the attestation schema"""
-  uid: ID
+  uid: ID!
+}
+
+"""Supported EAS attestation schemas and their related records"""
+type AttestationSchemaBaseType {
+  """Chain ID of the chains where the attestation schema is supported"""
+  chain_id: EthBigInt!
+  id: ID!
+
+  """Address of the resolver contract for the attestation schema"""
+  resolver: String!
+
+  """Whether the attestation schema is revocable"""
+  revocable: Boolean!
+
+  """String representation of the attestation schema"""
+  schema: String!
+
+  """Unique identifier for the attestation schema"""
+  uid: ID!
 }
 
 input AttestationSortOptions {
@@ -152,15 +204,21 @@ input AttestationWhereInput {
   creation_block_number: BigIntSearchOptions
   creation_block_timestamp: BigIntSearchOptions
   hypercerts: BasicHypercertWhereArgs
-  id: IdSearchOptions
   last_update_block_number: BigIntSearchOptions
   last_update_block_timestamp: BigIntSearchOptions
   metadata: BasicMetadataWhereInput
   recipient: StringSearchOptions
   resolver: StringSearchOptions
-  schema: StringSearchOptions
-  supported_schemas_id: StringSearchOptions
+  supported_schemas: BasicAttestationSchemaWhereInput
   token_id: StringSearchOptions
+  uid: StringSearchOptions
+}
+
+input BasicAttestationSchemaWhereInput {
+  chain_id: BigIntSearchOptions
+  resolver: StringSearchOptions
+  revocable: BooleanSearchOptions
+  schema: StringSearchOptions
   uid: StringSearchOptions
 }
 
@@ -171,13 +229,10 @@ input BasicAttestationWhereInput {
   contract_address: StringSearchOptions
   creation_block_number: BigIntSearchOptions
   creation_block_timestamp: BigIntSearchOptions
-  id: IdSearchOptions
   last_update_block_number: BigIntSearchOptions
   last_update_block_timestamp: BigIntSearchOptions
   recipient: StringSearchOptions
   resolver: StringSearchOptions
-  schema: StringSearchOptions
-  supported_schemas_id: StringSearchOptions
   token_id: StringSearchOptions
   uid: StringSearchOptions
 }

--- a/src/__generated__/routes/routes.ts
+++ b/src/__generated__/routes/routes.ts
@@ -80,13 +80,24 @@ const models: TsoaRoute.Models = {
         "type": {"dataType":"union","subSchemas":[{"ref":"EOAUserUpsertRequest"},{"ref":"MultisigUserUpsertRequest"}],"validators":{}},
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    "UploadStatus": {
+        "dataType": "refAlias",
+        "type": {"dataType":"union","subSchemas":[{"dataType":"enum","enums":["all"]},{"dataType":"enum","enums":["some"]},{"dataType":"enum","enums":["none"]}],"validators":{}},
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    "Record_string.string_": {
+        "dataType": "refAlias",
+        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{},"additionalProperties":{"dataType":"string"},"validators":{}},
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     "UploadResponse": {
         "dataType": "refObject",
         "properties": {
             "success": {"dataType":"boolean","required":true},
-            "message": {"dataType":"string"},
-            "errors": {"ref":"Record_string.string-or-string-Array_"},
+            "message": {"dataType":"string","required":true},
+            "uploadStatus": {"ref":"UploadStatus","required":true},
             "data": {"dataType":"nestedObjectLiteral","nestedProperties":{"failed":{"dataType":"array","array":{"dataType":"nestedObjectLiteral","nestedProperties":{"error":{"dataType":"string","required":true},"fileName":{"dataType":"string","required":true}}},"required":true},"results":{"dataType":"array","array":{"dataType":"nestedObjectLiteral","nestedProperties":{"fileName":{"dataType":"string","required":true},"cid":{"dataType":"string","required":true}}},"required":true}}},
+            "errors": {"ref":"Record_string.string_"},
         },
         "additionalProperties": false,
     },

--- a/src/__generated__/swagger.json
+++ b/src/__generated__/swagger.json
@@ -138,6 +138,22 @@
 					}
 				]
 			},
+			"UploadStatus": {
+				"type": "string",
+				"enum": [
+					"all",
+					"some",
+					"none"
+				]
+			},
+			"Record_string.string_": {
+				"properties": {},
+				"additionalProperties": {
+					"type": "string"
+				},
+				"type": "object",
+				"description": "Construct a type with a set of properties K of type T"
+			},
 			"UploadResponse": {
 				"properties": {
 					"success": {
@@ -146,8 +162,8 @@
 					"message": {
 						"type": "string"
 					},
-					"errors": {
-						"$ref": "#/components/schemas/Record_string.string-or-string-Array_"
+					"uploadStatus": {
+						"$ref": "#/components/schemas/UploadStatus"
 					},
 					"data": {
 						"properties": {
@@ -193,10 +209,15 @@
 							"results"
 						],
 						"type": "object"
+					},
+					"errors": {
+						"$ref": "#/components/schemas/Record_string.string_"
 					}
 				},
 				"required": [
-					"success"
+					"success",
+					"message",
+					"uploadStatus"
 				],
 				"type": "object",
 				"additionalProperties": false
@@ -1197,7 +1218,8 @@
 										"description": "- Array of files to upload (max 5 files, 10MB each)"
 									},
 									"jsonData": {
-										"type": "string"
+										"type": "string",
+										"description": "- Optional JSON string with additional metadata"
 									}
 								}
 							}

--- a/src/graphql/schemas/args/attestationArgs.ts
+++ b/src/graphql/schemas/args/attestationArgs.ts
@@ -15,7 +15,7 @@ class AttestationWhereInput extends BasicAttestationWhereInput {
   @Field(() => BasicMetadataWhereInput, { nullable: true })
   metadata?: BasicMetadataWhereInput;
   @Field(() => BasicAttestationSchemaWhereInput, { nullable: true })
-  supported_schemas?: BasicAttestationSchemaWhereInput;
+  eas_schema?: BasicAttestationSchemaWhereInput;
 }
 
 @InputType()

--- a/src/graphql/schemas/args/attestationArgs.ts
+++ b/src/graphql/schemas/args/attestationArgs.ts
@@ -6,6 +6,7 @@ import { BasicHypercertWhereArgs } from "../inputs/hypercertsInput.js";
 import type { OrderOptions } from "../inputs/orderOptions.js";
 import type { Attestation } from "../typeDefs/attestationTypeDefs.js";
 import { AttestationSortOptions } from "../inputs/sortOptions.js";
+import { BasicAttestationSchemaWhereInput } from "../inputs/attestationSchemaInput.js";
 
 @InputType()
 class AttestationWhereInput extends BasicAttestationWhereInput {
@@ -13,6 +14,8 @@ class AttestationWhereInput extends BasicAttestationWhereInput {
   hypercerts?: BasicHypercertWhereArgs;
   @Field(() => BasicMetadataWhereInput, { nullable: true })
   metadata?: BasicMetadataWhereInput;
+  @Field(() => BasicAttestationSchemaWhereInput, { nullable: true })
+  supported_schemas?: BasicAttestationSchemaWhereInput;
 }
 
 @InputType()

--- a/src/graphql/schemas/inputs/attestationInput.ts
+++ b/src/graphql/schemas/inputs/attestationInput.ts
@@ -1,20 +1,12 @@
 import { Field, InputType } from "type-graphql";
 import type { WhereOptions } from "./whereOptions.js";
-import {
-  IdSearchOptions,
-  BigIntSearchOptions,
-  StringSearchOptions,
-} from "./searchOptions.js";
+import { BigIntSearchOptions, StringSearchOptions } from "./searchOptions.js";
 import type { Attestation } from "../typeDefs/attestationTypeDefs.js";
 
 @InputType()
 export class BasicAttestationWhereInput implements WhereOptions<Attestation> {
-  @Field(() => IdSearchOptions, { nullable: true })
-  id?: IdSearchOptions;
   @Field(() => StringSearchOptions, { nullable: true })
   uid?: StringSearchOptions;
-  @Field(() => StringSearchOptions, { nullable: true })
-  supported_schemas_id?: StringSearchOptions;
   @Field(() => BigIntSearchOptions, { nullable: true })
   creation_block_timestamp?: BigIntSearchOptions;
   @Field(() => BigIntSearchOptions, { nullable: true })
@@ -29,8 +21,6 @@ export class BasicAttestationWhereInput implements WhereOptions<Attestation> {
   recipient?: StringSearchOptions;
   @Field(() => StringSearchOptions, { nullable: true })
   resolver?: StringSearchOptions;
-  @Field(() => StringSearchOptions, { nullable: true })
-  schema?: StringSearchOptions;
   @Field(() => StringSearchOptions, { nullable: true })
   attestation?: StringSearchOptions;
   @Field(() => BigIntSearchOptions, { nullable: true })

--- a/src/graphql/schemas/inputs/attestationSchemaInput.ts
+++ b/src/graphql/schemas/inputs/attestationSchemaInput.ts
@@ -1,19 +1,16 @@
 import { Field, InputType } from "type-graphql";
-import type { WhereOptions } from "./whereOptions.js";
+import type { AttestationSchema } from "../typeDefs/attestationSchemaTypeDefs.js";
 import {
-  BooleanSearchOptions,
-  IdSearchOptions,
   BigIntSearchOptions,
+  BooleanSearchOptions,
   StringSearchOptions,
 } from "./searchOptions.js";
-import type { AttestationSchema } from "../typeDefs/attestationSchemaTypeDefs.js";
+import type { WhereOptions } from "./whereOptions.js";
 
 @InputType()
 export class BasicAttestationSchemaWhereInput
   implements WhereOptions<AttestationSchema>
 {
-  @Field(() => IdSearchOptions, { nullable: true })
-  id?: IdSearchOptions | null;
   @Field(() => StringSearchOptions, { nullable: true })
   uid?: StringSearchOptions | null;
   @Field(() => BigIntSearchOptions, { nullable: true })

--- a/src/graphql/schemas/resolvers/attestationResolver.ts
+++ b/src/graphql/schemas/resolvers/attestationResolver.ts
@@ -54,6 +54,20 @@ class AttestationResolver extends AttestationBaseResolver {
       true,
     );
   }
+
+  @FieldResolver()
+  async supported_schemas(@Root() attestation: Attestation) {
+    if (!attestation.schema_uid) return;
+
+    return await this.getAttestationSchemas(
+      {
+        where: {
+          uid: { eq: attestation.schema_uid },
+        },
+      },
+      true,
+    );
+  }
 }
 
 export { AttestationResolver };

--- a/src/graphql/schemas/resolvers/attestationResolver.ts
+++ b/src/graphql/schemas/resolvers/attestationResolver.ts
@@ -56,7 +56,7 @@ class AttestationResolver extends AttestationBaseResolver {
   }
 
   @FieldResolver()
-  async supported_schemas(@Root() attestation: Attestation) {
+  async eas_schema(@Root() attestation: Attestation) {
     if (!attestation.schema_uid) return;
 
     return await this.getAttestationSchemas(

--- a/src/graphql/schemas/resolvers/attestationSchemaResolver.ts
+++ b/src/graphql/schemas/resolvers/attestationSchemaResolver.ts
@@ -11,7 +11,9 @@ import { GetAttestationSchemasArgs } from "../args/attestationSchemaArgs.js";
 import { createBaseResolver, DataResponse } from "./baseTypes.js";
 
 @ObjectType()
-class GetAttestationsSchemaResponse extends DataResponse(AttestationSchema) {}
+export default class GetAttestationsSchemaResponse extends DataResponse(
+  AttestationSchema,
+) {}
 
 const AttestationSchemaBaseResolver = createBaseResolver("attestationSchema");
 

--- a/src/graphql/schemas/resolvers/baseTypes.ts
+++ b/src/graphql/schemas/resolvers/baseTypes.ts
@@ -258,7 +258,6 @@ export function createBaseResolver<T extends ClassType>(
       try {
         const queries = this.supabaseCachingService.getAttestations(args);
 
-        console.log("GOT QUERY", queries);
         if (single) {
           const res = await queries.data.executeTakeFirst();
           return res ? this.parseAttestation(res) : null;

--- a/src/graphql/schemas/resolvers/baseTypes.ts
+++ b/src/graphql/schemas/resolvers/baseTypes.ts
@@ -1,18 +1,19 @@
-import { type ClassType, Field, Int, Resolver, ObjectType } from "type-graphql";
-import { SupabaseDataService } from "../../../services/SupabaseDataService.js";
 import { container } from "tsyringe";
+import { type ClassType, Field, Int, ObjectType, Resolver } from "type-graphql";
 import { SupabaseCachingService } from "../../../services/SupabaseCachingService.js";
-import { GetMetadataArgs } from "../args/metadataArgs.js";
+import { SupabaseDataService } from "../../../services/SupabaseDataService.js";
+import { GetAllowlistRecordsArgs } from "../args/allowlistRecordArgs.js";
+import { GetAttestationsArgs } from "../args/attestationArgs.js";
+import { GetAttestationSchemasArgs } from "../args/attestationSchemaArgs.js";
+import { GetBlueprintArgs } from "../args/blueprintArgs.js";
 import { GetContractsArgs } from "../args/contractArgs.js";
 import { GetFractionsArgs } from "../args/fractionArgs.js";
-import { GetAllowlistRecordsArgs } from "../args/allowlistRecordArgs.js";
-import { GetAttestationSchemasArgs } from "../args/attestationSchemaArgs.js";
-import { GetAttestationsArgs } from "../args/attestationArgs.js";
 import { GetHypercertsArgs } from "../args/hypercertsArgs.js";
+import { GetMetadataArgs } from "../args/metadataArgs.js";
+import { GetOrdersArgs } from "../args/orderArgs.js";
 import { GetSalesArgs } from "../args/salesArgs.js";
-import { GetUserArgs } from "../args/userArgs.js";
-import { GetBlueprintArgs } from "../args/blueprintArgs.js";
 import { GetSignatureRequestArgs } from "../args/signatureRequestArgs.js";
+import { GetUserArgs } from "../args/userArgs.js";
 
 export function DataResponse<TItem extends object>(
   TItemClass: ClassType<TItem>,
@@ -256,6 +257,8 @@ export function createBaseResolver<T extends ClassType>(
 
       try {
         const queries = this.supabaseCachingService.getAttestations(args);
+
+        console.log("GOT QUERY", queries);
         if (single) {
           const res = await queries.data.executeTakeFirst();
           return res ? this.parseAttestation(res) : null;

--- a/src/graphql/schemas/typeDefs/attestationSchemaTypeDefs.ts
+++ b/src/graphql/schemas/typeDefs/attestationSchemaTypeDefs.ts
@@ -1,44 +1,15 @@
-import { Field, ID, ObjectType } from "type-graphql";
-import { Attestation } from "./attestationTypeDefs.js";
-import { BasicTypeDef } from "./baseTypes/basicTypeDef.js";
-import { EthBigInt } from "../../scalars/ethBigInt.js";
+import { Field, ObjectType } from "type-graphql";
+import { AttestationBaseType } from "./baseTypes/attestationBaseType.js";
+import { AttestationSchemaBaseType } from "./baseTypes/attestationSchemaBaseType.js";
 
 @ObjectType({
   description: "Supported EAS attestation schemas and their related records",
 })
-class AttestationSchema extends BasicTypeDef {
-  @Field(() => EthBigInt, {
-    nullable: true,
-    description:
-      "Chain ID of the chains where the attestation schema is supported",
-  })
-  chain_id?: bigint | number | string;
-  @Field(() => ID, {
-    nullable: true,
-    description: "Unique identifier for the attestation schema",
-  })
-  uid?: string;
-  @Field({
-    nullable: true,
-    description: "Address of the resolver contract for the attestation schema",
-  })
-  resolver?: string;
-  @Field({
-    nullable: true,
-    description: "Whether the attestation schema is revocable",
-  })
-  revocable?: boolean;
-  @Field({
-    nullable: true,
-    description: "String representation of the attestation schema",
-  })
-  schema?: string;
-
-  @Field(() => [Attestation], {
-    nullable: true,
+class AttestationSchema extends AttestationSchemaBaseType {
+  @Field(() => [AttestationBaseType], {
     description: "List of attestations related to the attestation schema",
   })
-  records?: Attestation[] | null;
+  records?: AttestationBaseType[] | null;
 }
 
 export { AttestationSchema };

--- a/src/graphql/schemas/typeDefs/attestationTypeDefs.ts
+++ b/src/graphql/schemas/typeDefs/attestationTypeDefs.ts
@@ -1,6 +1,7 @@
 import { Field, ObjectType } from "type-graphql";
 import { AttestationBaseType } from "./baseTypes/attestationBaseType.js";
 import { HypercertBaseType } from "./baseTypes/hypercertBaseType.js";
+import { AttestationSchemaBaseType } from "./baseTypes/attestationSchemaBaseType.js";
 
 @ObjectType({
   description: "Attestation on the Ethereum Attestation Service",
@@ -8,10 +9,14 @@ import { HypercertBaseType } from "./baseTypes/hypercertBaseType.js";
 })
 class Attestation extends AttestationBaseType {
   @Field(() => HypercertBaseType, {
-    nullable: true,
     description: "Hypercert related to the attestation",
   })
   hypercert?: HypercertBaseType;
+
+  @Field(() => AttestationSchemaBaseType, {
+    description: "Schema related to the attestation",
+  })
+  supported_schemas?: AttestationSchemaBaseType;
 }
 
 export { Attestation };

--- a/src/graphql/schemas/typeDefs/attestationTypeDefs.ts
+++ b/src/graphql/schemas/typeDefs/attestationTypeDefs.ts
@@ -16,7 +16,7 @@ class Attestation extends AttestationBaseType {
   @Field(() => AttestationSchemaBaseType, {
     description: "Schema related to the attestation",
   })
-  supported_schemas?: AttestationSchemaBaseType;
+  eas_schema?: AttestationSchemaBaseType;
 }
 
 export { Attestation };

--- a/src/graphql/schemas/typeDefs/baseTypes/attestationBaseType.ts
+++ b/src/graphql/schemas/typeDefs/baseTypes/attestationBaseType.ts
@@ -8,14 +8,15 @@ import { GraphQLJSON } from "graphql-scalars";
 class AttestationBaseType extends BasicTypeDef {
   @Field(() => ID, {
     nullable: true,
-    description: "ID referencing the supported EAS schema in the database",
-  })
-  supported_schemas_id?: string;
-  @Field(() => ID, {
-    nullable: true,
     description: "Unique identifier for the attestation on EAS",
   })
   uid?: string;
+  @Field({
+    nullable: true,
+    description:
+      "Unique identifier of the EAS schema used to create the attestation",
+  })
+  schema_uid?: string;
 
   @Field(() => EthBigInt, {
     nullable: true,
@@ -53,12 +54,6 @@ class AttestationBaseType extends BasicTypeDef {
     description: "Address of the resolver contract for the attestation",
   })
   resolver?: string;
-  @Field({
-    nullable: true,
-    description:
-      "Unique identifier of the EAS schema used to create the attestation",
-  })
-  schema?: string;
   @Field(() => GraphQLJSON, {
     nullable: true,
     description: "Encoded data of the attestation",

--- a/src/graphql/schemas/typeDefs/baseTypes/attestationSchemaBaseType.ts
+++ b/src/graphql/schemas/typeDefs/baseTypes/attestationSchemaBaseType.ts
@@ -1,0 +1,32 @@
+import { Field, ID, ObjectType } from "type-graphql";
+import { EthBigInt } from "../../../scalars/ethBigInt.js";
+import { BasicTypeDef } from "./basicTypeDef.js";
+
+@ObjectType({
+  description: "Supported EAS attestation schemas and their related records",
+})
+class AttestationSchemaBaseType extends BasicTypeDef {
+  @Field(() => EthBigInt, {
+    description:
+      "Chain ID of the chains where the attestation schema is supported",
+  })
+  chain_id?: bigint | number | string;
+  @Field(() => ID, {
+    description: "Unique identifier for the attestation schema",
+  })
+  uid?: string;
+  @Field({
+    description: "Address of the resolver contract for the attestation schema",
+  })
+  resolver?: string;
+  @Field({
+    description: "Whether the attestation schema is revocable",
+  })
+  revocable?: boolean;
+  @Field({
+    description: "String representation of the attestation schema",
+  })
+  schema?: string;
+}
+
+export { AttestationSchemaBaseType };

--- a/src/graphql/schemas/utils/filters-kysely.ts
+++ b/src/graphql/schemas/utils/filters-kysely.ts
@@ -57,6 +57,8 @@ export const generateFilterValues = (
 
 export const getTablePrefix = (column: string): string => {
   switch (column) {
+    case "eas_schema":
+      return "supported_schemas";
     case "hypercerts":
       return "claims";
     case "contract":

--- a/src/services/SupabaseCachingService.ts
+++ b/src/services/SupabaseCachingService.ts
@@ -99,7 +99,15 @@ export class SupabaseCachingService extends BaseSupabaseService<CachingDatabase>
           )
           .$if(args.where?.metadata, (qb) =>
             qb.innerJoin("metadata", "metadata.uri", "claims.uri"),
+          )
+          .$if(args.where?.supported_schemas, (qb) =>
+            qb.innerJoin(
+              "supported_schemas",
+              "supported_schemas.id",
+              "attestations.supported_schemas_id",
+            ),
           );
+      case "supported_schemas":
       case "attestation_schema":
         return this.db.selectFrom("supported_schemas").selectAll();
       case "hypercerts":
@@ -164,9 +172,17 @@ export class SupabaseCachingService extends BaseSupabaseService<CachingDatabase>
           .$if(args.where?.metadata, (qb) =>
             qb.innerJoin("metadata", "metadata.uri", "claims.uri"),
           )
+          .$if(args.where?.supported_schemas, (qb) =>
+            qb.innerJoin(
+              "supported_schemas",
+              "supported_schemas.id",
+              "attestations.supported_schemas_id",
+            ),
+          )
           .select((expressionBuilder) => {
             return expressionBuilder.fn.countAll().as("count");
           });
+      case "supported_schemas":
       case "attestation_schema":
         return this.db
           .selectFrom("supported_schemas")

--- a/src/services/SupabaseCachingService.ts
+++ b/src/services/SupabaseCachingService.ts
@@ -100,13 +100,14 @@ export class SupabaseCachingService extends BaseSupabaseService<CachingDatabase>
           .$if(args.where?.metadata, (qb) =>
             qb.innerJoin("metadata", "metadata.uri", "claims.uri"),
           )
-          .$if(args.where?.supported_schemas, (qb) =>
+          .$if(args.where?.eas_schema, (qb) =>
             qb.innerJoin(
               "supported_schemas",
               "supported_schemas.id",
               "attestations.supported_schemas_id",
             ),
           );
+      case "eas_schema":
       case "supported_schemas":
       case "attestation_schema":
         return this.db.selectFrom("supported_schemas").selectAll();
@@ -172,7 +173,7 @@ export class SupabaseCachingService extends BaseSupabaseService<CachingDatabase>
           .$if(args.where?.metadata, (qb) =>
             qb.innerJoin("metadata", "metadata.uri", "claims.uri"),
           )
-          .$if(args.where?.supported_schemas, (qb) =>
+          .$if(args.where?.eas_schema, (qb) =>
             qb.innerJoin(
               "supported_schemas",
               "supported_schemas.id",
@@ -182,6 +183,7 @@ export class SupabaseCachingService extends BaseSupabaseService<CachingDatabase>
           .select((expressionBuilder) => {
             return expressionBuilder.fn.countAll().as("count");
           });
+      case "eas_schema":
       case "supported_schemas":
       case "attestation_schema":
         return this.db


### PR DESCRIPTION
This PR updates the attestation resolver so that you can query attestations based on EAS schema data like the `uid`