### PR TITLE
fix: check for presence of metadata.allowlist instead of allowlist

### DIFF
--- a/src/controllers/MetadataController.ts
+++ b/src/controllers/MetadataController.ts
@@ -131,7 +131,7 @@ export class MetadataController extends Controller {
         };
       }
 
-      if (allowList) {
+      if (metadataValidationResult.data.allowList) {
         this.setStatus(409);
         return {
           success: false,


### PR DESCRIPTION
reverts a regression introduced in commit
4f6bebaac90bb030a97f9a4caaabd54e71620ec8 where we started checking for allowlist, instead of metadata.allowlist. We should actually check for the presence of metadata.allowlist, to prevent the case where the user specifies both a CID and a json allowlist to the endpoint.