### PR TITLE
fix(graphql): filter on collections not working

### DIFF
--- a/src/graphql/schemas/resolvers/baseTypes.ts
+++ b/src/graphql/schemas/resolvers/baseTypes.ts
@@ -14,6 +14,7 @@ import { GetOrdersArgs } from "../args/orderArgs.js";
 import { GetSalesArgs } from "../args/salesArgs.js";
 import { GetSignatureRequestArgs } from "../args/signatureRequestArgs.js";
 import { GetUserArgs } from "../args/userArgs.js";
+import { GetCollectionsArgs } from "../args/collectionArgs.js";
 
 export function DataResponse<TItem extends object>(
   TItemClass: ClassType<TItem>,
@@ -402,6 +403,35 @@ export function createBaseResolver<T extends ClassType>(
         const error = e as Error;
         throw new Error(
           `[${entityFieldName}Resolver::getSignatureRequests] Error fetching signature requests: ${error.message}`,
+        );
+      }
+    }
+
+    getCollections(args: GetCollectionsArgs, single: boolean = false) {
+      console.debug(
+        `[${entityFieldName}Resolver::getCollections] Fetching collections`,
+      );
+
+      try {
+        const queries = this.supabaseDataService.getCollections(args);
+        if (single) {
+          return queries.data.executeTakeFirst();
+        }
+
+        return this.supabaseDataService.db
+          .transaction()
+          .execute(async (transaction) => {
+            const dataRes = await transaction.executeQuery(queries.data);
+            const countRes = await transaction.executeQuery(queries.count);
+            return {
+              data: dataRes.rows,
+              count: countRes.rows[0].count,
+            };
+          });
+      } catch (e) {
+        const error = e as Error;
+        throw new Error(
+          `[${entityFieldName}Resolver::getCollections] Error fetching collections: ${error.message}`,
         );
       }
     }

--- a/src/graphql/schemas/resolvers/collectionResolver.ts
+++ b/src/graphql/schemas/resolvers/collectionResolver.ts
@@ -25,12 +25,7 @@ class CollectionResolver extends CollectionBaseResolver {
   @Query(() => GetCollectionsResponse)
   async collections(@Args() args: GetCollectionsArgs) {
     try {
-      const res = await this.supabaseDataService.getCollections(args);
-
-      return {
-        data: res.data,
-        count: res.count,
-      };
+      return this.getCollections(args);
     } catch (e) {
       console.error("[CollectionResolver::collections] Error:", e);
       throw new Error(`Error fetching collections: ${(e as Error).message}`);

--- a/src/services/SupabaseDataService.ts
+++ b/src/services/SupabaseDataService.ts
@@ -431,24 +431,9 @@ export class SupabaseDataService extends BaseSupabaseService<KyselyDataDatabase>
       .execute();
   }
 
-  async getCollections(args: GetCollectionsArgs) {
-    let query = this.db
-      .selectFrom("collections")
-      .select([
-        "collections.id",
-        "collections.name",
-        "collections.description",
-        "collections.chain_ids",
-        "collections.hidden",
-        "collections.created_at",
-      ]);
-
-    if (args.sort?.by) {
-      query = this.applySorting(query, args.sort.by);
-    }
-
+  getCollections(args: GetCollectionsArgs) {
     return {
-      data: await query.execute(),
+      data: this.handleGetData("collections", args),
       count: this.handleGetCount("collections", args),
     };
   }


### PR DESCRIPTION
Without this patch filtering doesn't work on collections. The following query returns all collections instead of the one that's filtered for:

```graphql
{
  collections(where: { name: { eq: "test"}}) {
    data {
      name
      id
      hypercerts {
        hypercert_id
      }
    }
  }
}
```

The same holds true for ids.