### PR TITLE
Fix user controller to use custom Safe API Kit instance when interacting with Filecoin networks

### DIFF
--- a/src/lib/safe/SafeApiKitStrategy.ts
+++ b/src/lib/safe/SafeApiKitStrategy.ts
@@ -8,7 +8,7 @@ export class FilecoinMainnetStrategy implements SafeApiKitStrategy {
   createInstance(): SafeApiKit.default {
     return new SafeApiKit.default({
       chainId: BigInt(314),
-      txServiceUrl: "https://transaction.safe.filecoin.io/",
+      txServiceUrl: "https://transaction.safe.filecoin.io/api",
     });
   }
 }
@@ -17,7 +17,7 @@ export class FilecoinTestnetStrategy implements SafeApiKitStrategy {
   createInstance(): SafeApiKit.default {
     return new SafeApiKit.default({
       chainId: BigInt(314159),
-      txServiceUrl: "https://transaction-testnet.safe.filecoin.io/",
+      txServiceUrl: "https://transaction-testnet.safe.filecoin.io/api",
     });
   }
 }

--- a/src/lib/users/MultisigUpsertStrategy.ts
+++ b/src/lib/users/MultisigUpsertStrategy.ts
@@ -1,10 +1,11 @@
 import { z } from "zod";
-import SafeApiKit, { type SafeApiKitConfig } from "@safe-global/api-kit";
+import SafeApiKit from "@safe-global/api-kit";
 
 import { SignatureRequestPurpose } from "../../graphql/schemas/typeDefs/signatureRequestTypeDefs.js";
 import { SupabaseDataService } from "../../services/SupabaseDataService.js";
 import { UserResponse } from "../../types/api.js";
 import { isTypedMessage } from "../../utils/signatures.js";
+import { SafeApiStrategyFactory } from "../safe/SafeApiKitStrategy.js";
 
 import type { UserUpsertStrategy } from "./UserUpsertStrategy.js";
 import type { MultisigUpdateRequest } from "./schemas.js";
@@ -30,17 +31,16 @@ export default class MultisigUpdateStrategy implements UserUpsertStrategy {
   private readonly dataService: SupabaseDataService;
   // Safe SDKs only support CommonJS, so TS interprets `SafeApiKit` as a namespace.
   // https://docs.safe.global/sdk/overview
-  // Hence the explicit `default` here and on the instantiation further down.
+  // Hence the explicit `default` here.
   private readonly safeApiKit: SafeApiKit.default;
 
   constructor(
     private readonly address: string,
     private readonly request: MultisigUpdateRequest,
   ) {
-    const config: SafeApiKitConfig = {
-      chainId: BigInt(request.chain_id),
-    };
-    this.safeApiKit = new SafeApiKit.default(config);
+    this.safeApiKit = SafeApiStrategyFactory.getStrategy(
+      this.request.chain_id,
+    ).createInstance();
     this.dataService = new SupabaseDataService();
   }
 


### PR DESCRIPTION
Without this patch the Multisig upsert strategy is trying to construct the SafeAPIKit instance using the default constructor. The problem is that on Filecoin and Filecoin Calibration the transaction service is hosted by a third party and thus needs a custom txServiceUrl in the config.