### PR TITLE
fix: missing import of evmclientfactory in supabasedataservice

### DIFF
--- a/src/services/SupabaseDataService.ts
+++ b/src/services/SupabaseDataService.ts
@@ -21,6 +21,7 @@ import { applySorting } from "../graphql/schemas/utils/sorting.js";
 import type { DataDatabase as KyselyDataDatabase } from "../types/kyselySupabaseData.js";
 import type { Database as DataDatabase } from "../types/supabaseData.js";
 import { BaseSupabaseService } from "./BaseSupabaseService.js";
+import { EvmClientFactory } from "../client/evmClient.js";
 
 @singleton()
 export class SupabaseDataService extends BaseSupabaseService<KyselyDataDatabase> {


### PR DESCRIPTION
this was previously hidden due to the ts-expect-error comment, used because of the type mismatch