### PR TITLE
chore(sentry): lower polling rates

### DIFF
--- a/src/instrument.mjs
+++ b/src/instrument.mjs
@@ -1,6 +1,8 @@
 import * as Sentry from '@sentry/node';
 import { nodeProfilingIntegration } from "@sentry/profiling-node";
 
+const env = process.env.SENTRY_ENVIRONMENT;
+
 // Ensure to call this before importing any other modules!
 Sentry.init({
     dsn: process.env.SENTRY_DSN,
@@ -8,10 +10,11 @@ Sentry.init({
         nodeProfilingIntegration(),
     ],
     enabled:
-        process.env.SENTRY_ENVIRONMENT === "production" ||
-        process.env.SENTRY_ENVIRONMENT === "staging",
+        env === "production" ||
+        env === "staging",
 
     // Add Performance Monitoring by setting tracesSampleRate
-    // We recommend adjusting this value in production
-    tracesSampleRate: 1.0,
+    tracesSampleRate: env === "production" ? 0.1 : 1.0,
+
+    profilesSampleRate: env === "production" ? 0.1 : 1.0,
 });


### PR DESCRIPTION
As we're getting high loads on Sentry spans, we reduce the sampling rate from 1.0 to 0.1 for production and 1.0 on staging.

The reason for this is to primarily lower the amount of traces sent. However, we keep it 100% on staging to detect bugs and as traffic is lower there

Closing #270 