### PR TITLE
fix: select columns from correct table when filtering on fraction

### DIFF
--- a/src/services/SupabaseCachingService.ts
+++ b/src/services/SupabaseCachingService.ts
@@ -131,7 +131,7 @@ export class SupabaseCachingService extends BaseSupabaseService<CachingDatabase>
           .$if(args.where?.contract, (qb) =>
             qb.innerJoin("contracts", "contracts.id", "claims.contracts_id"),
           )
-          .selectAll(); // Select all columns from the claims table
+          .selectAll("claims"); // Select all columns from the claims table
       case "contracts":
         return this.db.selectFrom("contracts").selectAll();
       case "fractions":


### PR DESCRIPTION
Without specifying that selectAll() should give preference to columns present in the claims table, it ends up selecting fractions.units when the join is applied.