### PR TITLE
fix: select correct columns when pulling attestations from db

### DIFF
--- a/src/services/SupabaseCachingService.ts
+++ b/src/services/SupabaseCachingService.ts
@@ -93,19 +93,37 @@ export class SupabaseCachingService extends BaseSupabaseService<CachingDatabase>
       case "attestations":
         return this.db
           .selectFrom("attestations")
-          .selectAll("attestations")
+          .innerJoin(
+            "supported_schemas",
+            "supported_schemas.id",
+            "attestations.supported_schemas_id",
+          )
+          .select([
+            "attestations.id",
+            "attestations.uid",
+            "attestations.chain_id",
+            "attestations.contract_address",
+            "attestations.token_id",
+            "attestations.claims_id",
+            "attestations.recipient",
+            "attestations.attester",
+            "attestations.attestation",
+            "attestations.data",
+            "attestations.creation_block_timestamp",
+            "attestations.creation_block_number",
+            "attestations.last_update_block_number",
+            "attestations.last_update_block_timestamp",
+            "supported_schemas.uid as schema_uid",
+          ])
           .$if(args.where?.hypercerts, (qb) =>
-            qb.innerJoin("claims", "claims.id", "attestations.claims_id"),
+            qb.innerJoin(
+              "claims as claims",
+              "claims.id",
+              "attestations.claims_id",
+            ),
           )
           .$if(args.where?.metadata, (qb) =>
             qb.innerJoin("metadata", "metadata.uri", "claims.uri"),
-          )
-          .$if(args.where?.eas_schema, (qb) =>
-            qb.innerJoin(
-              "supported_schemas",
-              "supported_schemas.id",
-              "attestations.supported_schemas_id",
-            ),
           );
       case "eas_schema":
       case "supported_schemas":


### PR DESCRIPTION
Fixes a bug where the schema_uid was not selected correctly, which resulted in errors when fetching eas_schema using graphql as it's non-nullable.

NOTE: Querying attestations by metadata is broken, as it was before. I spent some time trying to fix this but ran into issues. I think it would be more time-efficient to revisit that after https://github.com/hypercerts-org/hypercerts-api/pull/263 has been merged. That issue is related to nested inner joins, eg attestations joins claims joins metadata. Created https://github.com/hypercerts-org/hypercerts-api/issues/280 to track that.