### PR TITLE
Safe integration marketplace listings

### DIFF
--- a/src/__generated__/routes/routes.ts
+++ b/src/__generated__/routes/routes.ts
@@ -29,9 +29,9 @@ const upload = multer({"limits":{"fileSize":8388608}});
 // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
 
 const models: TsoaRoute.Models = {
-    "Record_string.string-or-string-Array_": {
+    "Record_string.unknown_": {
         "dataType": "refAlias",
-        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{},"additionalProperties":{"dataType":"union","subSchemas":[{"dataType":"string"},{"dataType":"array","array":{"dataType":"string"}}]},"validators":{}},
+        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{},"additionalProperties":{"dataType":"any"},"validators":{}},
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     "UserResponse": {
@@ -39,7 +39,7 @@ const models: TsoaRoute.Models = {
         "properties": {
             "success": {"dataType":"boolean","required":true},
             "message": {"dataType":"string"},
-            "errors": {"ref":"Record_string.string-or-string-Array_"},
+            "errors": {"ref":"Record_string.unknown_"},
             "data": {"dataType":"nestedObjectLiteral","nestedProperties":{"address":{"dataType":"string","required":true}}},
         },
         "additionalProperties": false,
@@ -50,7 +50,7 @@ const models: TsoaRoute.Models = {
         "properties": {
             "success": {"dataType":"boolean","required":true},
             "message": {"dataType":"string"},
-            "errors": {"ref":"Record_string.string-or-string-Array_"},
+            "errors": {"ref":"Record_string.unknown_"},
         },
         "additionalProperties": false,
     },
@@ -168,7 +168,7 @@ const models: TsoaRoute.Models = {
         "properties": {
             "success": {"dataType":"boolean","required":true},
             "message": {"dataType":"string"},
-            "errors": {"ref":"Record_string.string-or-string-Array_"},
+            "errors": {"ref":"Record_string.unknown_"},
             "data": {"dataType":"nestedObjectLiteral","nestedProperties":{"cid":{"dataType":"string","required":true}}},
         },
         "additionalProperties": false,
@@ -189,7 +189,7 @@ const models: TsoaRoute.Models = {
         "properties": {
             "success": {"dataType":"boolean","required":true},
             "message": {"dataType":"string"},
-            "errors": {"ref":"Record_string.string-or-string-Array_"},
+            "errors": {"ref":"Record_string.unknown_"},
             "valid": {"dataType":"boolean","required":true},
             "data": {"dataType":"any"},
         },
@@ -204,24 +204,10 @@ const models: TsoaRoute.Models = {
         "additionalProperties": false,
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "OrderValidatorCode": {
-        "dataType": "refEnum",
-        "enums": [0,101,111,112,113,201,211,212,213,301,311,312,321,322,401,402,411,412,413,414,415,421,422,501,502,503,601,611,612,621,622,623,631,632,633,634,641,642,701,702,801,802,901,902],
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "Pick_Order.Exclude_keyofOrder.id-or-createdAt-or-invalidated-or-validator_codes__": {
-        "dataType": "refAlias",
-        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{},"validators":{}},
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "Omit_Order.id-or-createdAt-or-invalidated-or-validator_codes_": {
-        "dataType": "refAlias",
-        "type": {"ref":"Pick_Order.Exclude_keyofOrder.id-or-createdAt-or-invalidated-or-validator_codes__","validators":{}},
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "CreateOrderRequest": {
+    "EOACreateOrderRequest": {
         "dataType": "refObject",
         "properties": {
+            "type": {"dataType":"enum","enums":["eoa"],"required":true},
             "signature": {"dataType":"string","required":true},
             "chainId": {"dataType":"double","required":true},
             "quoteType": {"dataType":"double","required":true},
@@ -243,6 +229,36 @@ const models: TsoaRoute.Models = {
         "additionalProperties": false,
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    "MultisigCreateOrderRequest": {
+        "dataType": "refObject",
+        "properties": {
+            "type": {"dataType":"enum","enums":["multisig"],"required":true},
+            "messageHash": {"dataType":"string","required":true},
+            "chainId": {"dataType":"double","required":true},
+        },
+        "additionalProperties": false,
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    "Pick_EOACreateOrderRequest.Exclude_keyofEOACreateOrderRequest.type__": {
+        "dataType": "refAlias",
+        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"signature":{"dataType":"string","required":true},"chainId":{"dataType":"double","required":true},"quoteType":{"dataType":"double","required":true},"globalNonce":{"dataType":"string","required":true},"subsetNonce":{"dataType":"double","required":true},"orderNonce":{"dataType":"string","required":true},"strategyId":{"dataType":"double","required":true},"collectionType":{"dataType":"double","required":true},"collection":{"dataType":"string","required":true},"currency":{"dataType":"string","required":true},"signer":{"dataType":"string","required":true},"startTime":{"dataType":"double","required":true},"endTime":{"dataType":"double","required":true},"price":{"dataType":"string","required":true},"itemIds":{"dataType":"array","array":{"dataType":"string"},"required":true},"amounts":{"dataType":"array","array":{"dataType":"double"},"required":true},"additionalParameters":{"dataType":"string","required":true}},"validators":{}},
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    "Omit_EOACreateOrderRequest.type_": {
+        "dataType": "refAlias",
+        "type": {"ref":"Pick_EOACreateOrderRequest.Exclude_keyofEOACreateOrderRequest.type__","validators":{}},
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    "LegacyCreateOrderRequest": {
+        "dataType": "refAlias",
+        "type": {"ref":"Omit_EOACreateOrderRequest.type_","validators":{}},
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    "CreateOrderRequest": {
+        "dataType": "refAlias",
+        "type": {"dataType":"union","subSchemas":[{"ref":"EOACreateOrderRequest"},{"ref":"MultisigCreateOrderRequest"},{"ref":"LegacyCreateOrderRequest"}],"validators":{}},
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     "UpdateOrderNonceRequest": {
         "dataType": "refObject",
         "properties": {
@@ -250,6 +266,11 @@ const models: TsoaRoute.Models = {
             "chainId": {"dataType":"double","required":true},
         },
         "additionalProperties": false,
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    "OrderValidatorCode": {
+        "dataType": "refEnum",
+        "enums": [0,101,111,112,113,201,211,212,213,301,311,312,321,322,401,402,411,412,413,414,415,421,422,501,502,503,601,611,612,621,622,623,631,632,633,634,641,642,701,702,801,802,901,902],
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     "ValidateOrderRequest": {
@@ -266,7 +287,7 @@ const models: TsoaRoute.Models = {
         "properties": {
             "success": {"dataType":"boolean","required":true},
             "message": {"dataType":"string"},
-            "errors": {"ref":"Record_string.string-or-string-Array_"},
+            "errors": {"ref":"Record_string.unknown_"},
             "data": {"dataType":"nestedObjectLiteral","nestedProperties":{"id":{"dataType":"string","required":true}}},
         },
         "additionalProperties": false,
@@ -306,7 +327,7 @@ const models: TsoaRoute.Models = {
         "properties": {
             "success": {"dataType":"boolean","required":true},
             "message": {"dataType":"string"},
-            "errors": {"ref":"Record_string.string-or-string-Array_"},
+            "errors": {"ref":"Record_string.unknown_"},
             "data": {"dataType":"nestedObjectLiteral","nestedProperties":{"blueprint_id":{"dataType":"double","required":true}}},
         },
         "additionalProperties": false,

--- a/src/__generated__/routes/routes.ts
+++ b/src/__generated__/routes/routes.ts
@@ -9,6 +9,8 @@ import { UploadController } from './../../controllers/UploadController.js';
 // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
 import { SignatureRequestController } from './../../controllers/SignatureRequestController.js';
 // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+import { MonitoringController } from './../../controllers/MonitoringController.js';
+// WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
 import { MetadataController } from './../../controllers/MetadataController.js';
 // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
 import { MarketplaceController } from './../../controllers/MarketplaceController.js';
@@ -112,6 +114,18 @@ const models: TsoaRoute.Models = {
         "additionalProperties": false,
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    "process.NodeJS.MemoryUsage": {
+        "dataType": "refObject",
+        "properties": {
+            "rss": {"dataType":"double","required":true},
+            "heapTotal": {"dataType":"double","required":true},
+            "heapUsed": {"dataType":"double","required":true},
+            "external": {"dataType":"double","required":true},
+            "arrayBuffers": {"dataType":"double","required":true},
+        },
+        "additionalProperties": false,
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     "HypercertClaimdata": {
         "dataType": "refObject",
         "properties": {
@@ -192,17 +206,17 @@ const models: TsoaRoute.Models = {
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     "OrderValidatorCode": {
         "dataType": "refEnum",
-        "enums": [0,101,111,112,113,201,211,212,213,301,311,312,321,322,401,402,411,412,413,414,415,421,422,501,502,503,601,611,612,621,622,623,631,632,633,634,701,702,801,802,901,902],
+        "enums": [0,101,111,112,113,201,211,212,213,301,311,312,321,322,401,402,411,412,413,414,415,421,422,501,502,503,601,611,612,621,622,623,631,632,633,634,641,642,701,702,801,802,901,902],
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "Pick__additionalParameters-string--amounts-number-Array--chainId-number--collection-string--collectionType-number--createdAt-string--currency-string--endTime-number--globalNonce-string--id-string--invalidated-boolean--itemIds-string-Array--orderNonce-string--price-string--quoteType-number--signature-string--signer-string--startTime-number--strategyId-number--subsetNonce-number--validator_codes-number-Array_.Exclude_keyof_additionalParameters-string--amounts-number-Array--chainId-number--collection-string--collectionType-number--createdAt-string--currency-string--endTime-number--globalNonce-string--id-string--invalidated-boolean--itemIds-string-Array--orderNonce-string--price-string--quoteType-number--signature-string--signer-string--startTime-number--strategyId-number--subsetNonce-number--validator_codes-number-Array_.id-or-createdAt-or-invalidated-or-validator_codes__": {
+    "Pick_Order.Exclude_keyofOrder.id-or-createdAt-or-invalidated-or-validator_codes__": {
         "dataType": "refAlias",
         "type": {"dataType":"nestedObjectLiteral","nestedProperties":{},"validators":{}},
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "Omit__additionalParameters-string--amounts-number-Array--chainId-number--collection-string--collectionType-number--createdAt-string--currency-string--endTime-number--globalNonce-string--id-string--invalidated-boolean--itemIds-string-Array--orderNonce-string--price-string--quoteType-number--signature-string--signer-string--startTime-number--strategyId-number--subsetNonce-number--validator_codes-number-Array_.id-or-createdAt-or-invalidated-or-validator_codes_": {
+    "Omit_Order.id-or-createdAt-or-invalidated-or-validator_codes_": {
         "dataType": "refAlias",
-        "type": {"ref":"Pick__additionalParameters-string--amounts-number-Array--chainId-number--collection-string--collectionType-number--createdAt-string--currency-string--endTime-number--globalNonce-string--id-string--invalidated-boolean--itemIds-string-Array--orderNonce-string--price-string--quoteType-number--signature-string--signer-string--startTime-number--strategyId-number--subsetNonce-number--validator_codes-number-Array_.Exclude_keyof_additionalParameters-string--amounts-number-Array--chainId-number--collection-string--collectionType-number--createdAt-string--currency-string--endTime-number--globalNonce-string--id-string--invalidated-boolean--itemIds-string-Array--orderNonce-string--price-string--quoteType-number--signature-string--signer-string--startTime-number--strategyId-number--subsetNonce-number--validator_codes-number-Array_.id-or-createdAt-or-invalidated-or-validator_codes__","validators":{}},
+        "type": {"ref":"Pick_Order.Exclude_keyofOrder.id-or-createdAt-or-invalidated-or-validator_codes__","validators":{}},
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     "CreateOrderRequest": {
@@ -477,6 +491,35 @@ export function RegisterRoutes(app: Router) {
                 next,
                 validatedArgs,
                 successStatus: 200,
+              });
+            } catch (err) {
+                return next(err);
+            }
+        });
+        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+        app.get('/monitoring/health',
+            ...(fetchMiddlewares<RequestHandler>(MonitoringController)),
+            ...(fetchMiddlewares<RequestHandler>(MonitoringController.prototype.healthCheck)),
+
+            async function MonitoringController_healthCheck(request: ExRequest, response: ExResponse, next: any) {
+            const args: Record<string, TsoaRoute.ParameterSchema> = {
+            };
+
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({ args, request, response });
+
+                const controller = new MonitoringController();
+
+              await templateService.apiHandler({
+                methodName: 'healthCheck',
+                controller,
+                response,
+                next,
+                validatedArgs,
+                successStatus: undefined,
               });
             } catch (err) {
                 return next(err);

--- a/src/__generated__/swagger.json
+++ b/src/__generated__/swagger.json
@@ -243,6 +243,39 @@
 				"type": "object",
 				"additionalProperties": false
 			},
+			"process.NodeJS.MemoryUsage": {
+				"properties": {
+					"rss": {
+						"type": "number",
+						"format": "double"
+					},
+					"heapTotal": {
+						"type": "number",
+						"format": "double"
+					},
+					"heapUsed": {
+						"type": "number",
+						"format": "double"
+					},
+					"external": {
+						"type": "number",
+						"format": "double"
+					},
+					"arrayBuffers": {
+						"type": "number",
+						"format": "double"
+					}
+				},
+				"required": [
+					"rss",
+					"heapTotal",
+					"heapUsed",
+					"external",
+					"arrayBuffers"
+				],
+				"type": "object",
+				"additionalProperties": false
+			},
 			"HypercertClaimdata": {
 				"description": "Properties of an impact claim",
 				"properties": {
@@ -613,6 +646,8 @@
 					632,
 					633,
 					634,
+					641,
+					642,
 					701,
 					702,
 					801,
@@ -622,13 +657,13 @@
 				],
 				"type": "number"
 			},
-			"Pick__additionalParameters-string--amounts-number-Array--chainId-number--collection-string--collectionType-number--createdAt-string--currency-string--endTime-number--globalNonce-string--id-string--invalidated-boolean--itemIds-string-Array--orderNonce-string--price-string--quoteType-number--signature-string--signer-string--startTime-number--strategyId-number--subsetNonce-number--validator_codes-number-Array_.Exclude_keyof_additionalParameters-string--amounts-number-Array--chainId-number--collection-string--collectionType-number--createdAt-string--currency-string--endTime-number--globalNonce-string--id-string--invalidated-boolean--itemIds-string-Array--orderNonce-string--price-string--quoteType-number--signature-string--signer-string--startTime-number--strategyId-number--subsetNonce-number--validator_codes-number-Array_.id-or-createdAt-or-invalidated-or-validator_codes__": {
+			"Pick_Order.Exclude_keyofOrder.id-or-createdAt-or-invalidated-or-validator_codes__": {
 				"properties": {},
 				"type": "object",
 				"description": "From T, pick a set of properties whose keys are in the union K"
 			},
-			"Omit__additionalParameters-string--amounts-number-Array--chainId-number--collection-string--collectionType-number--createdAt-string--currency-string--endTime-number--globalNonce-string--id-string--invalidated-boolean--itemIds-string-Array--orderNonce-string--price-string--quoteType-number--signature-string--signer-string--startTime-number--strategyId-number--subsetNonce-number--validator_codes-number-Array_.id-or-createdAt-or-invalidated-or-validator_codes_": {
-				"$ref": "#/components/schemas/Pick__additionalParameters-string--amounts-number-Array--chainId-number--collection-string--collectionType-number--createdAt-string--currency-string--endTime-number--globalNonce-string--id-string--invalidated-boolean--itemIds-string-Array--orderNonce-string--price-string--quoteType-number--signature-string--signer-string--startTime-number--strategyId-number--subsetNonce-number--validator_codes-number-Array_.Exclude_keyof_additionalParameters-string--amounts-number-Array--chainId-number--collection-string--collectionType-number--createdAt-string--currency-string--endTime-number--globalNonce-string--id-string--invalidated-boolean--itemIds-string-Array--orderNonce-string--price-string--quoteType-number--signature-string--signer-string--startTime-number--strategyId-number--subsetNonce-number--validator_codes-number-Array_.id-or-createdAt-or-invalidated-or-validator_codes__",
+			"Omit_Order.id-or-createdAt-or-invalidated-or-validator_codes_": {
+				"$ref": "#/components/schemas/Pick_Order.Exclude_keyofOrder.id-or-createdAt-or-invalidated-or-validator_codes__",
 				"description": "Construct a type with the properties of T except for those in type K."
 			},
 			"CreateOrderRequest": {
@@ -1359,6 +1394,47 @@
 				"parameters": []
 			}
 		},
+		"/monitoring/health": {
+			"get": {
+				"operationId": "HealthCheck",
+				"responses": {
+					"200": {
+						"description": "Ok",
+						"content": {
+							"application/json": {
+								"schema": {
+									"properties": {
+										"memory": {
+											"$ref": "#/components/schemas/process.NodeJS.MemoryUsage"
+										},
+										"timestamp": {
+											"type": "number",
+											"format": "double"
+										},
+										"uptime": {
+											"type": "number",
+											"format": "double"
+										},
+										"status": {
+											"type": "string"
+										}
+									},
+									"required": [
+										"memory",
+										"timestamp",
+										"uptime",
+										"status"
+									],
+									"type": "object"
+								}
+							}
+						}
+					}
+				},
+				"security": [],
+				"parameters": []
+			}
+		},
 		"/v1/metadata": {
 			"post": {
 				"operationId": "StoreMetadata",
@@ -1717,7 +1793,7 @@
 												"data": {
 													"properties": {
 														"order": {
-															"$ref": "#/components/schemas/Omit__additionalParameters-string--amounts-number-Array--chainId-number--collection-string--collectionType-number--createdAt-string--currency-string--endTime-number--globalNonce-string--id-string--invalidated-boolean--itemIds-string-Array--orderNonce-string--price-string--quoteType-number--signature-string--signer-string--startTime-number--strategyId-number--subsetNonce-number--validator_codes-number-Array_.id-or-createdAt-or-invalidated-or-validator_codes_"
+															"$ref": "#/components/schemas/Omit_Order.id-or-createdAt-or-invalidated-or-validator_codes_"
 														},
 														"validatorCodes": {
 															"items": {

--- a/src/__generated__/swagger.json
+++ b/src/__generated__/swagger.json
@@ -7,21 +7,9 @@
 		"requestBodies": {},
 		"responses": {},
 		"schemas": {
-			"Record_string.string-or-string-Array_": {
+			"Record_string.unknown_": {
 				"properties": {},
-				"additionalProperties": {
-					"anyOf": [
-						{
-							"type": "string"
-						},
-						{
-							"items": {
-								"type": "string"
-							},
-							"type": "array"
-						}
-					]
-				},
+				"additionalProperties": {},
 				"type": "object",
 				"description": "Construct a type with a set of properties K of type T"
 			},
@@ -34,7 +22,7 @@
 						"type": "string"
 					},
 					"errors": {
-						"$ref": "#/components/schemas/Record_string.string-or-string-Array_"
+						"$ref": "#/components/schemas/Record_string.unknown_"
 					},
 					"data": {
 						"properties": {
@@ -63,7 +51,7 @@
 						"type": "string"
 					},
 					"errors": {
-						"$ref": "#/components/schemas/Record_string.string-or-string-Array_"
+						"$ref": "#/components/schemas/Record_string.unknown_"
 					}
 				},
 				"required": [
@@ -533,7 +521,7 @@
 						"type": "string"
 					},
 					"errors": {
-						"$ref": "#/components/schemas/Record_string.string-or-string-Array_"
+						"$ref": "#/components/schemas/Record_string.unknown_"
 					},
 					"data": {
 						"properties": {
@@ -581,7 +569,7 @@
 						"type": "string"
 					},
 					"errors": {
-						"$ref": "#/components/schemas/Record_string.string-or-string-Array_"
+						"$ref": "#/components/schemas/Record_string.unknown_"
 					},
 					"valid": {
 						"type": "boolean"
@@ -607,66 +595,130 @@
 				"type": "object",
 				"additionalProperties": false
 			},
-			"OrderValidatorCode": {
-				"description": "Error errors returned by the order validator contract",
-				"enum": [
-					0,
-					101,
-					111,
-					112,
-					113,
-					201,
-					211,
-					212,
-					213,
-					301,
-					311,
-					312,
-					321,
-					322,
-					401,
-					402,
-					411,
-					412,
-					413,
-					414,
-					415,
-					421,
-					422,
-					501,
-					502,
-					503,
-					601,
-					611,
-					612,
-					621,
-					622,
-					623,
-					631,
-					632,
-					633,
-					634,
-					641,
-					642,
-					701,
-					702,
-					801,
-					802,
-					901,
-					902
+			"EOACreateOrderRequest": {
+				"properties": {
+					"type": {
+						"type": "string",
+						"enum": [
+							"eoa"
+						],
+						"nullable": false
+					},
+					"signature": {
+						"type": "string"
+					},
+					"chainId": {
+						"type": "number",
+						"format": "double"
+					},
+					"quoteType": {
+						"type": "number",
+						"format": "double"
+					},
+					"globalNonce": {
+						"type": "string"
+					},
+					"subsetNonce": {
+						"type": "number",
+						"format": "double"
+					},
+					"orderNonce": {
+						"type": "string"
+					},
+					"strategyId": {
+						"type": "number",
+						"format": "double"
+					},
+					"collectionType": {
+						"type": "number",
+						"format": "double"
+					},
+					"collection": {
+						"type": "string"
+					},
+					"currency": {
+						"type": "string"
+					},
+					"signer": {
+						"type": "string"
+					},
+					"startTime": {
+						"type": "number",
+						"format": "double"
+					},
+					"endTime": {
+						"type": "number",
+						"format": "double"
+					},
+					"price": {
+						"type": "string"
+					},
+					"itemIds": {
+						"items": {
+							"type": "string"
+						},
+						"type": "array"
+					},
+					"amounts": {
+						"items": {
+							"type": "number",
+							"format": "double"
+						},
+						"type": "array"
+					},
+					"additionalParameters": {
+						"type": "string"
+					}
+				},
+				"required": [
+					"type",
+					"signature",
+					"chainId",
+					"quoteType",
+					"globalNonce",
+					"subsetNonce",
+					"orderNonce",
+					"strategyId",
+					"collectionType",
+					"collection",
+					"currency",
+					"signer",
+					"startTime",
+					"endTime",
+					"price",
+					"itemIds",
+					"amounts",
+					"additionalParameters"
 				],
-				"type": "number"
-			},
-			"Pick_Order.Exclude_keyofOrder.id-or-createdAt-or-invalidated-or-validator_codes__": {
-				"properties": {},
 				"type": "object",
-				"description": "From T, pick a set of properties whose keys are in the union K"
+				"additionalProperties": false
 			},
-			"Omit_Order.id-or-createdAt-or-invalidated-or-validator_codes_": {
-				"$ref": "#/components/schemas/Pick_Order.Exclude_keyofOrder.id-or-createdAt-or-invalidated-or-validator_codes__",
-				"description": "Construct a type with the properties of T except for those in type K."
+			"MultisigCreateOrderRequest": {
+				"properties": {
+					"type": {
+						"type": "string",
+						"enum": [
+							"multisig"
+						],
+						"nullable": false
+					},
+					"messageHash": {
+						"type": "string"
+					},
+					"chainId": {
+						"type": "number",
+						"format": "double"
+					}
+				},
+				"required": [
+					"type",
+					"messageHash",
+					"chainId"
+				],
+				"type": "object",
+				"additionalProperties": false
 			},
-			"CreateOrderRequest": {
+			"Pick_EOACreateOrderRequest.Exclude_keyofEOACreateOrderRequest.type__": {
 				"properties": {
 					"signature": {
 						"type": "string"
@@ -754,7 +806,27 @@
 					"additionalParameters"
 				],
 				"type": "object",
-				"additionalProperties": false
+				"description": "From T, pick a set of properties whose keys are in the union K"
+			},
+			"Omit_EOACreateOrderRequest.type_": {
+				"$ref": "#/components/schemas/Pick_EOACreateOrderRequest.Exclude_keyofEOACreateOrderRequest.type__",
+				"description": "Construct a type with the properties of T except for those in type K."
+			},
+			"LegacyCreateOrderRequest": {
+				"$ref": "#/components/schemas/Omit_EOACreateOrderRequest.type_"
+			},
+			"CreateOrderRequest": {
+				"anyOf": [
+					{
+						"$ref": "#/components/schemas/EOACreateOrderRequest"
+					},
+					{
+						"$ref": "#/components/schemas/MultisigCreateOrderRequest"
+					},
+					{
+						"$ref": "#/components/schemas/LegacyCreateOrderRequest"
+					}
+				]
 			},
 			"UpdateOrderNonceRequest": {
 				"properties": {
@@ -772,6 +844,56 @@
 				],
 				"type": "object",
 				"additionalProperties": false
+			},
+			"OrderValidatorCode": {
+				"description": "Error errors returned by the order validator contract",
+				"enum": [
+					0,
+					101,
+					111,
+					112,
+					113,
+					201,
+					211,
+					212,
+					213,
+					301,
+					311,
+					312,
+					321,
+					322,
+					401,
+					402,
+					411,
+					412,
+					413,
+					414,
+					415,
+					421,
+					422,
+					501,
+					502,
+					503,
+					601,
+					611,
+					612,
+					621,
+					622,
+					623,
+					631,
+					632,
+					633,
+					634,
+					641,
+					642,
+					701,
+					702,
+					801,
+					802,
+					901,
+					902
+				],
+				"type": "number"
 			},
 			"ValidateOrderRequest": {
 				"properties": {
@@ -802,7 +924,7 @@
 						"type": "string"
 					},
 					"errors": {
-						"$ref": "#/components/schemas/Record_string.string-or-string-Array_"
+						"$ref": "#/components/schemas/Record_string.unknown_"
 					},
 					"data": {
 						"properties": {
@@ -1031,7 +1153,7 @@
 						"type": "string"
 					},
 					"errors": {
-						"$ref": "#/components/schemas/Record_string.string-or-string-Array_"
+						"$ref": "#/components/schemas/Record_string.unknown_"
 					},
 					"data": {
 						"properties": {
@@ -1769,9 +1891,13 @@
 								"schema": {
 									"anyOf": [
 										{
+											"$ref": "#/components/schemas/BaseResponse"
+										},
+										{
 											"properties": {
-												"error": {},
-												"data": {},
+												"error": {
+													"type": "string"
+												},
 												"message": {
 													"type": "string"
 												},
@@ -1781,190 +1907,8 @@
 											},
 											"required": [
 												"error",
-												"data",
 												"message",
 												"success"
-											],
-											"type": "object"
-										},
-										{
-											"properties": {
-												"error": {},
-												"data": {
-													"properties": {
-														"order": {
-															"$ref": "#/components/schemas/Omit_Order.id-or-createdAt-or-invalidated-or-validator_codes_"
-														},
-														"validatorCodes": {
-															"items": {
-																"$ref": "#/components/schemas/OrderValidatorCode"
-															},
-															"type": "array"
-														},
-														"valid": {
-															"type": "boolean"
-														},
-														"id": {
-															"type": "string"
-														}
-													},
-													"required": [
-														"order",
-														"validatorCodes",
-														"valid",
-														"id"
-													],
-													"type": "object"
-												},
-												"success": {
-													"type": "boolean"
-												},
-												"message": {
-													"type": "string"
-												}
-											},
-											"required": [
-												"data",
-												"success",
-												"message"
-											],
-											"type": "object"
-										},
-										{
-											"properties": {
-												"error": {},
-												"data": {
-													"properties": {
-														"validator_codes": {
-															"items": {
-																"type": "number",
-																"format": "double"
-															},
-															"type": "array"
-														},
-														"subsetNonce": {
-															"type": "number",
-															"format": "double"
-														},
-														"strategyId": {
-															"type": "number",
-															"format": "double"
-														},
-														"startTime": {
-															"type": "number",
-															"format": "double"
-														},
-														"signer": {
-															"type": "string"
-														},
-														"signature": {
-															"type": "string"
-														},
-														"quoteType": {
-															"type": "number",
-															"format": "double"
-														},
-														"price": {
-															"type": "string"
-														},
-														"orderNonce": {
-															"type": "string"
-														},
-														"invalidated": {
-															"type": "boolean"
-														},
-														"id": {
-															"type": "string"
-														},
-														"hypercert_id": {
-															"type": "string"
-														},
-														"globalNonce": {
-															"type": "string"
-														},
-														"endTime": {
-															"type": "number",
-															"format": "double"
-														},
-														"currency": {
-															"type": "string"
-														},
-														"createdAt": {
-															"type": "string"
-														},
-														"collectionType": {
-															"type": "number",
-															"format": "double"
-														},
-														"collection": {
-															"type": "string"
-														},
-														"chainId": {
-															"type": "number",
-															"format": "double"
-														},
-														"additionalParameters": {
-															"type": "string"
-														},
-														"hash": {
-															"type": "string"
-														},
-														"status": {
-															"type": "string"
-														},
-														"amounts": {
-															"items": {
-																"type": "number",
-																"format": "double"
-															},
-															"type": "array"
-														},
-														"itemIds": {
-															"items": {
-																"type": "string"
-															},
-															"type": "array"
-														}
-													},
-													"required": [
-														"validator_codes",
-														"subsetNonce",
-														"strategyId",
-														"startTime",
-														"signer",
-														"signature",
-														"quoteType",
-														"price",
-														"orderNonce",
-														"invalidated",
-														"id",
-														"hypercert_id",
-														"globalNonce",
-														"endTime",
-														"currency",
-														"createdAt",
-														"collectionType",
-														"collection",
-														"chainId",
-														"additionalParameters",
-														"hash",
-														"status",
-														"amounts",
-														"itemIds"
-													],
-													"type": "object"
-												},
-												"success": {
-													"type": "boolean"
-												},
-												"message": {
-													"type": "string"
-												}
-											},
-											"required": [
-												"data",
-												"success",
-												"message"
 											],
 											"type": "object"
 										}
@@ -1992,7 +1936,7 @@
 						}
 					}
 				},
-				"description": "Submits a new order for validation and storage on the database.",
+				"description": "Submits a new order for validation and storage on the database.\n\nFor backwards compatibility, the old v1 order format is also supported. (Example 3)",
 				"tags": [
 					"Marketplace"
 				],
@@ -2004,6 +1948,66 @@
 						"application/json": {
 							"schema": {
 								"$ref": "#/components/schemas/CreateOrderRequest"
+							},
+							"examples": {
+								"Example 1": {
+									"value": {
+										"type": "eoa",
+										"signature": "0x1234567890abcdef",
+										"chainId": 11155111,
+										"quoteType": 0,
+										"globalNonce": "1",
+										"subsetNonce": 0,
+										"orderNonce": "1",
+										"strategyId": 0,
+										"collectionType": 0,
+										"collection": "0x1234567890abcdef",
+										"currency": "0x1234567890abcdef",
+										"signer": "0x1234567890abcdef",
+										"startTime": 1620000000,
+										"endTime": 1630000000,
+										"price": "1000000000000000000",
+										"itemIds": [
+											"1"
+										],
+										"amounts": [
+											1
+										],
+										"additionalParameters": "0x"
+									}
+								},
+								"Example 2": {
+									"value": {
+										"type": "multisig",
+										"messageHash": "0x1234567890abcdef",
+										"chainId": 11155111
+									}
+								},
+								"Example 3": {
+									"value": {
+										"signature": "0x1234567890abcdef",
+										"chainId": 11155111,
+										"quoteType": 0,
+										"globalNonce": "1",
+										"subsetNonce": 0,
+										"orderNonce": "1",
+										"strategyId": 0,
+										"collectionType": 0,
+										"collection": "0x1234567890abcdef",
+										"currency": "0x1234567890abcdef",
+										"signer": "0x1234567890abcdef",
+										"startTime": 1620000000,
+										"endTime": 1630000000,
+										"price": "1000000000000000000",
+										"itemIds": [
+											"1"
+										],
+										"amounts": [
+											1
+										],
+										"additionalParameters": "0x"
+									}
+								}
 							}
 						}
 					}

--- a/src/commands/CommandFactory.ts
+++ b/src/commands/CommandFactory.ts
@@ -1,8 +1,9 @@
 import { Database } from "../types/supabaseData.js";
 import { ISafeApiCommand } from "../types/safe-signatures.js";
 
-import { UserUpsertCommand } from "./UserUpsertCommand.js";
+import { MarketplaceCreateOrderCommand } from "./MarketplaceCreateOrderCommand.js";
 import { SafeApiCommand } from "./SafeApiCommand.js";
+import { UserUpsertCommand } from "./UserUpsertCommand.js";
 
 type SignatureRequest =
   Database["public"]["Tables"]["signature_requests"]["Row"];
@@ -14,6 +15,12 @@ export function getCommand(request: SignatureRequest): ISafeApiCommand {
         request.safe_address,
         request.message_hash,
         // The type is lying. It's a string.
+        Number(request.chain_id),
+      );
+    case "create_marketplace_order":
+      return new MarketplaceCreateOrderCommand(
+        request.safe_address,
+        request.message_hash,
         Number(request.chain_id),
       );
     default:

--- a/src/commands/MarketplaceCreateOrderCommand.ts
+++ b/src/commands/MarketplaceCreateOrderCommand.ts
@@ -1,0 +1,83 @@
+import { getAddress } from "viem";
+
+import {
+  SAFE_CREATE_ORDER_MESSAGE_SCHEMA,
+  SafeCreateOrderMessage,
+} from "../lib/marketplace/schemas.js";
+import { isTypedMessage } from "../utils/signatures.js";
+import MarketplaceCreateOrderSignatureVerifier from "../lib/safe/signature-verification/MarketplaceCreateOrderSignatureVerifier.js";
+
+import { SafeApiCommand } from "./SafeApiCommand.js";
+import { getHypercertTokenId } from "../utils/tokenIds.js";
+
+export class MarketplaceCreateOrderCommand extends SafeApiCommand {
+  async execute(): Promise<void> {
+    const signatureRequest = await this.dataService.getSignatureRequest(
+      this.safeAddress,
+      this.messageHash,
+    );
+
+    if (!signatureRequest || signatureRequest.status !== "pending") {
+      return;
+    }
+
+    const safeMessage = await this.safeApiKit.getMessage(this.messageHash);
+
+    if (!isTypedMessage(safeMessage.message)) {
+      throw new Error("Unexpected message type: not EIP712TypedData");
+    }
+
+    const message = SAFE_CREATE_ORDER_MESSAGE_SCHEMA.safeParse(
+      safeMessage.message,
+    );
+    if (!message.success) {
+      console.error("Unexpected message format", message.error);
+      throw new Error("Unexpected message format");
+    }
+
+    const verifier = new MarketplaceCreateOrderSignatureVerifier(
+      Number(signatureRequest.chain_id),
+      getAddress(this.safeAddress),
+      message.data,
+    );
+
+    if (
+      !(await verifier.verify(safeMessage.preparedSignature as `0x${string}`))
+    ) {
+      console.error(`Signature verification failed: ${this.getId()}`);
+      return;
+    }
+
+    await this.updateDatabase(message.data, safeMessage.preparedSignature);
+    console.log(`Signature request executed: ${this.getId()}`);
+  }
+
+  private async updateDatabase(
+    message: SafeCreateOrderMessage,
+    signature: string,
+  ): Promise<void> {
+    const orderDetails = message.message;
+    const tokenId = orderDetails.itemIds[0];
+    const hypercertTokenId = getHypercertTokenId(BigInt(tokenId));
+    const formattedHypercertId = `${this.chainId}-${orderDetails.collection}-${hypercertTokenId.toString()}`;
+
+    const insertEntity = {
+      ...orderDetails,
+      chainId: this.chainId,
+      signature,
+      hypercert_id: formattedHypercertId,
+      // TODO: This should actually be BigInt[]. After bitbeckers big rewrite, we should have another look at this.
+      // Check https://github.com/hypercerts-org/hypercerts-api/pull/263
+      // FYI: https://stackoverflow.com/a/4090577 recommends parseInt to use explicit radix (10)
+      amounts: orderDetails.amounts.map((x) => parseInt(x, 10)),
+    };
+
+    await this.dataService.storeOrder(insertEntity);
+
+    await this.dataService.updateSignatureRequestStatus(
+      this.safeAddress,
+      this.messageHash,
+      "executed",
+    );
+  }
+}

--- a/src/controllers/UserController.ts
+++ b/src/controllers/UserController.ts
@@ -15,7 +15,7 @@ import type {
   BaseResponse,
   UserResponse,
 } from "../types/api.js";
-import { UserUpsertError } from "../lib/users/errors.js";
+import { isUserUpsertError } from "../lib/users/errors.js";
 import { USER_UPDATE_REQUEST_SCHEMA } from "../lib/users/schemas.js";
 import { createStrategy } from "../lib/users/UserUpsertStrategy.js";
 import { ParseError } from "../lib/errors/request-parsing.js";
@@ -69,8 +69,8 @@ export class UserController extends Controller {
   }
 
   errorResponse(error: unknown) {
-    if (error instanceof UserUpsertError) {
-      this.setStatus(error.code);
+    if (isUserUpsertError(error)) {
+      this.setStatus(error.statusCode);
       return {
         success: false,
         message: error.message,

--- a/src/controllers/UserController.ts
+++ b/src/controllers/UserController.ts
@@ -18,6 +18,7 @@ import type {
 import { UserUpsertError } from "../lib/users/errors.js";
 import { USER_UPDATE_REQUEST_SCHEMA } from "../lib/users/schemas.js";
 import { createStrategy } from "../lib/users/UserUpsertStrategy.js";
+import { ParseError } from "../lib/errors/request-parsing.js";
 
 @Route("v1/users")
 @Tags("Users")
@@ -94,9 +95,7 @@ function parseInput(
 ): z.infer<typeof USER_UPDATE_REQUEST_SCHEMA> {
   const parsedBody = USER_UPDATE_REQUEST_SCHEMA.safeParse(input);
   if (!parsedBody.success) {
-    const userUpdateError = new UserUpsertError(400, "Invalid input");
-    userUpdateError.errors = JSON.parse(parsedBody.error.toString());
-    throw userUpdateError;
+    throw new ParseError(parsedBody);
   }
   return parsedBody.data;
 }

--- a/src/lib/errors/controller.ts
+++ b/src/lib/errors/controller.ts
@@ -1,0 +1,47 @@
+import { BaseResponse } from "../../types/api.js";
+
+/**
+ * Base error class for handling controller errors
+ * @extends Error
+ */
+export class ControllerError extends Error {
+  /**
+   * HTTP status code for response
+   */
+  statusCode: number;
+
+  /**
+   * Any additional, more fine-grained error details
+   */
+  errors?: Record<string, unknown>;
+
+  /**
+   * Creates a new ControllerError
+   * @param message - Error message
+   * @param statusCode - HTTP status code for response
+   */
+  constructor(
+    message = "Unknown error",
+    statusCode = 500,
+    errors?: Record<string, unknown>,
+  ) {
+    super(message);
+    this.name = this.constructor.name;
+    this.statusCode = statusCode;
+    this.errors = errors;
+    // This is needed for proper inheritance with built-in Error in TypeScript
+    Object.setPrototypeOf(this, ControllerError.prototype);
+  }
+
+  toResponse(): BaseResponse {
+    return {
+      success: false,
+      message: this.message,
+      errors: this.errors,
+    };
+  }
+}
+
+export function isControllerError(error: unknown): error is ControllerError {
+  return error instanceof ControllerError;
+}

--- a/src/lib/errors/request-parsing.ts
+++ b/src/lib/errors/request-parsing.ts
@@ -1,0 +1,23 @@
+import { SafeParseError } from "zod";
+
+import { ControllerError } from "./controller.js";
+
+export class ParseError extends ControllerError {
+  public input: SafeParseError<unknown>;
+
+  constructor(input: SafeParseError<unknown>) {
+    super(`Invalid input: ${JSON.stringify(input.error)}`, 400);
+    this.name = "ParseError";
+    this.input = input;
+    // This is needed for proper inheritance with built-in Error in TypeScript
+    Object.setPrototypeOf(this, ParseError.prototype);
+  }
+
+  public toJSON() {
+    return JSON.parse(this.input.error.toString());
+  }
+}
+
+export function isParseError(error: unknown): error is ParseError {
+  return error instanceof ParseError;
+}

--- a/src/lib/marketplace/EOACreateOrderStrategy.ts
+++ b/src/lib/marketplace/EOACreateOrderStrategy.ts
@@ -1,0 +1,102 @@
+import {
+  HypercertExchangeClient,
+  utils,
+} from "@hypercerts-org/marketplace-sdk";
+import { verifyTypedData } from "ethers";
+
+import { EvmClientFactory } from "../../client/evmClient.js";
+import { DataResponse } from "../../types/api.js";
+import { getFractionsById } from "../../utils/getFractionsById.js";
+import { getHypercertTokenId } from "../../utils/tokenIds.js";
+
+import { MarketplaceStrategy } from "./MarketplaceStrategy.js";
+import { EOACreateOrderRequest } from "./schemas.js";
+import * as Errors from "./errors.js";
+
+export default class EOACreateOrderStrategy extends MarketplaceStrategy {
+  constructor(private readonly request: EOACreateOrderRequest) {
+    super();
+  }
+
+  // TODO: Clean up this long ass method. I copied it 1:1 from the controller.
+  async executeCreate(): Promise<DataResponse<unknown>> {
+    const { signature, chainId, ...makerOrder } = this.request;
+
+    const hec = new HypercertExchangeClient(
+      chainId,
+      // @ts-expect-error Typing issue with provider
+      EvmClientFactory.createEthersClient(chainId),
+    );
+    const typedData = hec.getTypedDataDomain();
+
+    const recoveredAddress = verifyTypedData(
+      typedData,
+      utils.makerTypes,
+      makerOrder,
+      signature,
+    );
+
+    if (!(recoveredAddress.toLowerCase() === makerOrder.signer.toLowerCase())) {
+      throw new Errors.SignerMismatch();
+    }
+
+    const [validationResult] = await hec.checkOrdersValidity([
+      { ...makerOrder, signature, chainId, id: "temporary" },
+    ]);
+    if (!validationResult.valid) {
+      throw new Errors.InvalidOrder(validationResult);
+    }
+
+    const tokenIds = makerOrder.itemIds.map(
+      (id) => `${chainId}-${makerOrder.collection}-${id}`,
+    );
+
+    const fractions = await Promise.all(
+      tokenIds.map((fractionId) => getFractionsById(fractionId)),
+    );
+
+    // Check if all fractions exist
+    if (fractions.some((fraction) => !fraction)) {
+      throw new Errors.MissingFractions();
+    }
+
+    const allFractions = fractions.flatMap((fraction) => fraction || []);
+    // Check if all fractions are owned by signer
+    if (
+      !allFractions.every(
+        (claimToken) =>
+          claimToken?.owner_address?.toLowerCase() ===
+          recoveredAddress.toLowerCase(),
+      )
+    ) {
+      throw new Errors.FractionOwnershipMismatch();
+    }
+
+    const tokenId = makerOrder.itemIds[0];
+    const hypercertTokenId = getHypercertTokenId(BigInt(tokenId));
+    const formattedHypercertId = `${chainId}-${makerOrder.collection}-${hypercertTokenId.toString()}`;
+    // Add to database
+    const insertEntity = {
+      ...makerOrder,
+      chainId,
+      signature,
+      hypercert_id: formattedHypercertId,
+    };
+    console.log("[marketplace-api] Inserting order entity", insertEntity);
+
+    const result = await this.dataService.storeOrder(insertEntity);
+
+    return this.returnSuccess(
+      "Added order to database",
+      result.data
+        ? {
+            ...result.data,
+            itemIds: result.data.itemIds as string[],
+            amounts: result.data.amounts as number[],
+            status: "VALID",
+            hash: "0x",
+          }
+        : null,
+    );
+  }
+}

--- a/src/lib/marketplace/MarketplaceStrategy.ts
+++ b/src/lib/marketplace/MarketplaceStrategy.ts
@@ -1,0 +1,19 @@
+import { DataResponse } from "../../types/api.js";
+import { SupabaseDataService } from "../../services/SupabaseDataService.js";
+
+export abstract class MarketplaceStrategy {
+  protected readonly dataService: SupabaseDataService;
+
+  constructor() {
+    this.dataService = new SupabaseDataService();
+  }
+
+  abstract executeCreate(): Promise<DataResponse<unknown>>;
+
+  protected returnSuccess(
+    message: string,
+    data: unknown,
+  ): DataResponse<unknown> {
+    return { success: true, message, data };
+  }
+}

--- a/src/lib/marketplace/MarketplaceStrategyFactory.ts
+++ b/src/lib/marketplace/MarketplaceStrategyFactory.ts
@@ -1,0 +1,20 @@
+import {
+  EOACreateOrderRequest,
+  MultisigCreateOrderRequest,
+} from "./schemas.js";
+import { MarketplaceStrategy } from "./MarketplaceStrategy.js";
+import EOACreateOrderStrategy from "./EOACreateOrderStrategy.js";
+import MultisigCreateOrderStrategy from "./MultisigCreateOrderStrategy.js";
+
+export function createMarketplaceStrategy(
+  request: MultisigCreateOrderRequest | EOACreateOrderRequest,
+): MarketplaceStrategy {
+  switch (request.type) {
+    case "eoa":
+      return new EOACreateOrderStrategy(request);
+    case "multisig":
+      return new MultisigCreateOrderStrategy(request);
+    default:
+      throw new Error("Invalid marketplace request type");
+  }
+}

--- a/src/lib/marketplace/MultisigCreateOrderStrategy.ts
+++ b/src/lib/marketplace/MultisigCreateOrderStrategy.ts
@@ -1,0 +1,194 @@
+import {
+  HypercertExchangeClient,
+  Order,
+  OrderValidatorCode,
+} from "@hypercerts-org/marketplace-sdk";
+import SafeApiKit from "@safe-global/api-kit";
+
+import { DataResponse } from "../../types/api.js";
+import { EvmClientFactory } from "../../client/evmClient.js";
+import { getFractionsById } from "../../utils/getFractionsById.js";
+import { getHypercertTokenId } from "../../utils/tokenIds.js";
+import { isTypedMessage } from "../../utils/signatures.js";
+import { SafeApiStrategyFactory } from "../safe/SafeApiKitStrategy.js";
+
+import { MarketplaceStrategy } from "./MarketplaceStrategy.js";
+import {
+  MultisigCreateOrderRequest,
+  SAFE_CREATE_ORDER_MESSAGE_SCHEMA,
+  SafeCreateOrderMessage,
+} from "./schemas.js";
+import * as Errors from "./errors.js";
+
+type ValidatableOrder = Omit<
+  Order,
+  "createdAt" | "invalidated" | "validator_codes"
+>;
+
+type OrderDetails = SafeCreateOrderMessage["message"];
+
+export default class MultisigCreateOrderStrategy extends MarketplaceStrategy {
+  private readonly safeApiKit: SafeApiKit.default;
+
+  constructor(private readonly request: MultisigCreateOrderRequest) {
+    super();
+    this.safeApiKit = SafeApiStrategyFactory.getStrategy(
+      request.chainId,
+    ).createInstance();
+  }
+
+  async executeCreate(): Promise<DataResponse<unknown>> {
+    const { messageHash } = this.request;
+
+    const { message, safe: safeAddress } =
+      await this.safeApiKit.getMessage(messageHash);
+
+    if (!isTypedMessage(message)) {
+      throw new Errors.InvalidMessageFormat();
+    }
+
+    // Check if signature request already exists
+    const existingRequest = await this.dataService.getSignatureRequest(
+      safeAddress,
+      messageHash,
+    );
+
+    if (existingRequest) {
+      return this.returnSuccess("Signature request already exists", {
+        status: existingRequest.status,
+        signer: safeAddress,
+      });
+    }
+
+    const parsedMessage = this.parseMessage(message);
+    await this.validateOrder(parsedMessage.message);
+    await this.createSignatureRequest(
+      messageHash,
+      safeAddress,
+      parsedMessage.message,
+    );
+
+    return this.returnSuccess("Signature request created successfully", {
+      status: "SIGNATURE_REQUEST_PENDING",
+      signer: safeAddress,
+      hypercert_id: this.formatHypercertId(parsedMessage.message),
+    });
+  }
+
+  private parseMessage(message?: unknown): SafeCreateOrderMessage {
+    try {
+      return SAFE_CREATE_ORDER_MESSAGE_SCHEMA.parse(message);
+    } catch (error) {
+      console.error(
+        "[MarketplaceMultisigStrategy] Message validation error:",
+        error,
+      );
+      throw new Errors.InvalidMessageFormat();
+    }
+  }
+
+  private async validateOrder(orderDetails: OrderDetails): Promise<void> {
+    const orderToValidate: ValidatableOrder = {
+      quoteType: orderDetails.quoteType,
+      globalNonce: orderDetails.globalNonce.toString(),
+      subsetNonce: Number(orderDetails.subsetNonce),
+      orderNonce: orderDetails.orderNonce.toString(),
+      strategyId: Number(orderDetails.strategyId),
+      collectionType: orderDetails.collectionType,
+      collection: orderDetails.collection,
+      currency: orderDetails.currency,
+      signer: orderDetails.signer,
+      startTime: Number(orderDetails.startTime),
+      endTime: Number(orderDetails.endTime),
+      price: orderDetails.price.toString(),
+      itemIds: orderDetails.itemIds.map((id) => id.toString()),
+      amounts: orderDetails.amounts.map((amount) => Number(amount)),
+      additionalParameters: orderDetails.additionalParameters,
+      signature: "0x",
+      chainId: this.request.chainId,
+      id: "temporary",
+    };
+
+    const hec = new HypercertExchangeClient(
+      this.request.chainId,
+      // @ts-expect-error Typing issue with provider
+      EvmClientFactory.createEthersClient(this.request.chainId),
+    );
+
+    const [validationResult] = await hec.checkOrdersValidity([orderToValidate]);
+
+    if (!validationResult.valid) {
+      const errorCodes = validationResult.validatorCodes || [];
+
+      // Check if error codes follow the expected pattern. Everything needs to be 0 (valid),
+      // except for the signature validation error. This is because when this request is
+      // made, the message is missing one or more signatures.
+      // The signature will be validated in the command. It's only skipped for now.
+      // TODO: get the command name when ready
+      const isValidErrorPattern = errorCodes.every((code, index) => {
+        if (index === 3) {
+          return (
+            code ===
+              OrderValidatorCode.MISSING_IS_VALID_SIGNATURE_FUNCTION_EIP1271 ||
+            code === OrderValidatorCode.ORDER_EXPECTED_TO_BE_VALID
+          );
+        }
+        return code === 0;
+      });
+
+      // Only proceed if it's the expected signature validation error pattern
+      if (!isValidErrorPattern) {
+        throw new Errors.InvalidOrder(validationResult);
+      }
+    }
+    const tokenIds = orderDetails.itemIds.map(
+      (id) => `${this.request.chainId}-${orderDetails.collection}-${id}`,
+    );
+
+    const fractions = await Promise.all(
+      tokenIds.map((fractionId) => getFractionsById(fractionId)),
+    );
+
+    // Check if all fractions exist
+    if (fractions.some((fraction) => !fraction)) {
+      throw new Errors.MissingFractions();
+    }
+  }
+
+  private formatHypercertId(orderDetails: OrderDetails): string {
+    const tokenId = orderDetails.itemIds[0];
+    const hypercertTokenId = getHypercertTokenId(BigInt(tokenId));
+    const formattedHypercertId = `${this.request.chainId}-${orderDetails.collection}-${hypercertTokenId.toString()}`;
+    return formattedHypercertId;
+  }
+
+  private async createSignatureRequest(
+    messageHash: string,
+    safeAddress: string,
+    orderDetails: OrderDetails,
+  ): Promise<void> {
+    // Convert bigint values to strings for JSON serialization
+    const messageForStorage = {
+      ...orderDetails,
+      hypercert_id: this.formatHypercertId(orderDetails),
+      globalNonce: orderDetails.globalNonce.toString(),
+      subsetNonce: orderDetails.subsetNonce.toString(),
+      orderNonce: orderDetails.orderNonce.toString(),
+      strategyId: orderDetails.strategyId.toString(),
+      startTime: orderDetails.startTime.toString(),
+      endTime: orderDetails.endTime.toString(),
+      price: orderDetails.price.toString(),
+      itemIds: orderDetails.itemIds.map((id) => id.toString()),
+      amounts: orderDetails.amounts.map((amount) => amount.toString()),
+    };
+
+    await this.dataService.addSignatureRequest({
+      chain_id: this.request.chainId,
+      safe_address: safeAddress,
+      message_hash: messageHash,
+      message: messageForStorage,
+      purpose: "create_marketplace_order",
+      timestamp: Math.floor(Date.now() / 1000),
+    });
+  }
+}

--- a/src/lib/marketplace/errors.ts
+++ b/src/lib/marketplace/errors.ts
@@ -1,0 +1,32 @@
+import { ControllerError } from "../errors/controller.js";
+
+export class SignerMismatch extends ControllerError {
+  constructor() {
+    super("Recovered address is not equal to signer of order", 401);
+  }
+}
+
+export class InvalidOrder extends ControllerError {
+  constructor(validationResult?: Record<string, unknown>) {
+    super("Order is not valid within contract", 400);
+    this.errors = validationResult;
+  }
+}
+
+export class MissingFractions extends ControllerError {
+  constructor() {
+    super("Not all fractions in itemIds exist", 400);
+  }
+}
+
+export class FractionOwnershipMismatch extends ControllerError {
+  constructor() {
+    super("Not all fractions are owned by signer", 400);
+  }
+}
+
+export class InvalidMessageFormat extends ControllerError {
+  constructor() {
+    super("Invalid message format", 400);
+  }
+}

--- a/src/lib/marketplace/request-parser.ts
+++ b/src/lib/marketplace/request-parser.ts
@@ -1,0 +1,30 @@
+import { LegacyCreateOrderRequest } from "../../types/api.js";
+import { ParseError } from "../errors/request-parsing.js";
+
+import { CREATE_ORDER_REQUEST_SCHEMA } from "./schemas.js";
+
+export function parseCreateOrderRequest(input: unknown) {
+  if (isLegacyCreateOrderRequest(input)) {
+    // For backwards compatibility, if `type` is not provided, default to "eoa"
+    input = { ...input, type: "eoa" };
+  }
+
+  const parsedBody = CREATE_ORDER_REQUEST_SCHEMA.safeParse(input);
+  if (!parsedBody.success) {
+    throw new ParseError(parsedBody);
+  }
+  return parsedBody.data;
+}
+
+function isLegacyCreateOrderRequest(
+  requestBody: unknown,
+): requestBody is LegacyCreateOrderRequest {
+  return (
+    typeof requestBody === "object" &&
+    requestBody !== null &&
+    "signature" in requestBody &&
+    !("type" in requestBody)
+  );
+}
+
+// TODO: add functions for other requests updateOrderNonce, validateOrder, deleteOrder

--- a/src/lib/marketplace/schemas.ts
+++ b/src/lib/marketplace/schemas.ts
@@ -1,0 +1,112 @@
+import { z } from "zod";
+import { isAddress } from "viem";
+import { addressesByNetwork } from "@hypercerts-org/marketplace-sdk";
+import { isParsableToBigInt } from "../../utils/isParsableToBigInt.js";
+
+const BASE_CREATE_ORDER_SCHEMA = z.object({
+  chainId: z.number(),
+});
+
+export const EOA_CREATE_ORDER_SCHEMA = BASE_CREATE_ORDER_SCHEMA.extend({
+  type: z.literal("eoa"),
+  signature: z.string(),
+  chainId: z.number(),
+  quoteType: z.number(),
+  globalNonce: z.string(),
+  subsetNonce: z.number(),
+  orderNonce: z.string(),
+  strategyId: z.number(),
+  collectionType: z.number(),
+  collection: z.string(),
+  currency: z.string(),
+  signer: z.string(),
+  startTime: z.number(),
+  endTime: z.number(),
+  price: z.string(),
+  itemIds: z.array(z.string()),
+  amounts: z.array(z.number()),
+  additionalParameters: z.string(),
+})
+  .refine(
+    ({ chainId }) => isParsableToBigInt(chainId),
+    `ChainId is not parseable as bigint`,
+  )
+  .refine(
+    ({ globalNonce }) => isParsableToBigInt(globalNonce),
+    `globalNonce is not parseable as bigint`,
+  )
+  .refine(
+    ({ orderNonce }) => isParsableToBigInt(orderNonce),
+    `orderNonce is not parseable as bigint`,
+  )
+  .refine(
+    ({ price }) => isParsableToBigInt(price),
+    `price is not parseable as bigint`,
+  )
+  .refine(({ price }) => {
+    const priceBigInt = BigInt(price);
+    return priceBigInt > 0n;
+  }, `Price must be greater than 0`)
+  .refine(({ currency }) => isAddress(currency), `Invalid currency address`)
+  .refine(({ signer }) => isAddress(signer), `Invalid signer address`)
+  .refine(({ itemIds }) => itemIds.length > 0, `itemIds must not be empty`)
+  .refine(({ amounts }) => amounts.length > 0, `amounts must not be empty`)
+  .refine(
+    ({ itemIds, amounts }) => itemIds.length === amounts.length,
+    "itemIds and amounts must have the same length",
+  )
+  .refine(
+    ({ startTime, endTime }) => startTime < endTime,
+    "startTime must be less than endTime",
+  )
+  .refine(
+    ({ collection }) => isAddress(collection),
+    `Invalid collection address`,
+  )
+  .refine(
+    ({ collection, chainId }) =>
+      // @ts-expect-error Typing issue with chainId
+      addressesByNetwork[chainId]?.MINTER?.toLowerCase() ===
+      collection.toLowerCase(),
+    `Collection address does not match the minter address for chainId`,
+  );
+
+export const MULTISIG_CREATE_ORDER_SCHEMA = BASE_CREATE_ORDER_SCHEMA.extend({
+  type: z.literal("multisig"),
+  messageHash: z.string(),
+});
+
+export const CREATE_ORDER_REQUEST_SCHEMA = z.union([
+  EOA_CREATE_ORDER_SCHEMA,
+  MULTISIG_CREATE_ORDER_SCHEMA,
+]);
+
+export type EOACreateOrderRequest = z.infer<typeof EOA_CREATE_ORDER_SCHEMA>;
+export type MultisigCreateOrderRequest = z.infer<
+  typeof MULTISIG_CREATE_ORDER_SCHEMA
+>;
+export type CreateOrderRequest = z.infer<typeof CREATE_ORDER_REQUEST_SCHEMA>;
+
+export const SAFE_CREATE_ORDER_MESSAGE_SCHEMA = z.object({
+  message: z.object({
+    quoteType: z.number(),
+    globalNonce: z.string(),
+    subsetNonce: z.number(),
+    orderNonce: z.string(),
+    strategyId: z.number(),
+    collectionType: z.number(),
+    collection: z.string(),
+    currency: z.string(),
+    signer: z.string(),
+    startTime: z.number(),
+    endTime: z.number(),
+    price: z.string(),
+    itemIds: z.array(z.string()),
+    amounts: z.array(z.string()),
+    additionalParameters: z.string(),
+  }),
+});
+
+export type SafeCreateOrderMessage = z.infer<
+  typeof SAFE_CREATE_ORDER_MESSAGE_SCHEMA
+>;

--- a/src/lib/safe/signature-verification/MarketplaceCreateOrderSignatureVerifier.ts
+++ b/src/lib/safe/signature-verification/MarketplaceCreateOrderSignatureVerifier.ts
@@ -1,0 +1,47 @@
+import { SafeCreateOrderMessage } from "../../marketplace/schemas.js";
+import SafeSignatureVerifier from "./SafeSignatureVerifier.js";
+
+export default class MarketplaceCreateOrderSignatureVerifier extends SafeSignatureVerifier {
+  private message: SafeCreateOrderMessage;
+
+  constructor(
+    chainId: number,
+    safeAddress: `0x${string}`,
+    message: SafeCreateOrderMessage,
+  ) {
+    super(chainId, safeAddress);
+    this.message = message;
+  }
+
+  buildTypedData() {
+    return {
+      types: {
+        Maker: [
+          { name: "quoteType", type: "uint8" },
+          { name: "globalNonce", type: "uint256" },
+          { name: "subsetNonce", type: "uint256" },
+          { name: "orderNonce", type: "uint256" },
+          { name: "strategyId", type: "uint256" },
+          { name: "collectionType", type: "uint8" },
+          { name: "collection", type: "address" },
+          { name: "currency", type: "address" },
+          { name: "signer", type: "address" },
+          { name: "startTime", type: "uint256" },
+          { name: "endTime", type: "uint256" },
+          { name: "price", type: "uint256" },
+          { name: "itemIds", type: "uint256[]" },
+          { name: "amounts", type: "uint256[]" },
+          { name: "additionalParameters", type: "bytes" },
+        ],
+        EIP712Domain: [
+          { name: "name", type: "string" },
+          { name: "version", type: "string" },
+          { name: "chainId", type: "uint256" },
+          { name: "verifyingContract", type: "address" },
+        ],
+      },
+      primaryType: "Maker",
+      message: this.message.message,
+    };
+  }
+}

--- a/src/lib/users/MultisigUpsertStrategy.ts
+++ b/src/lib/users/MultisigUpsertStrategy.ts
@@ -60,7 +60,14 @@ export default class MultisigUpdateStrategy implements UserUpsertStrategy {
     if (!parseResult.success) {
       throw new UserUpsertError(
         400,
-        parseResult.error.errors.map((e) => e.message).join("; "),
+        "Couldn't parse user update message",
+        parseResult.error.errors.reduce((acc, err) => {
+          const path = err.path.join(".");
+          return {
+            ...acc,
+            [path]: err.message,
+          };
+        }, {}),
       );
     }
     console.log("Creating signature request for", parseResult);

--- a/src/lib/users/errors.ts
+++ b/src/lib/users/errors.ts
@@ -1,11 +1,12 @@
-import { UserResponse } from "../../types/api.js";
+import { ControllerError } from "../errors/controller.js";
 
-export class UserUpsertError extends Error {
-  code: number;
-  public errors: UserResponse["errors"];
-  constructor(code: number, message: string) {
-    super(message);
+export class UserUpsertError extends ControllerError {
+  constructor(code: number, message: string, errors?: Record<string, unknown>) {
+    super(message, code, errors);
     this.name = "UserUpdateError";
-    this.code = code;
   }
+}
+
+export function isUserUpsertError(error: unknown): error is UserUpsertError {
+  return error !== null && error instanceof UserUpsertError;
 }

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -9,7 +9,7 @@ import type { HypercertMetadata } from "@hypercerts-org/sdk";
 export interface BaseResponse {
   success: boolean; // Whether the API call itself succeeded
   message?: string; // Human readable message about the operation
-  errors?: Record<string, string | string[]>; // Any errors that occurred
+  errors?: Record<string, unknown>; // Any errors that occurred
 }
 
 // Response for operations that return data
@@ -99,6 +99,52 @@ export type AddOrUpdateUserRequest =
   | MultisigUserUpsertRequest;
 
 export interface UserResponse extends DataResponse<{ address: string }> {}
+
+// Marketplace-related interfaces
+
+export interface EOACreateOrderRequest {
+  type: "eoa";
+  signature: string;
+  chainId: number;
+  quoteType: number;
+  globalNonce: string;
+  subsetNonce: number;
+  orderNonce: string;
+  strategyId: number;
+  collectionType: number;
+  collection: string;
+  currency: string;
+  signer: string;
+  startTime: number;
+  endTime: number;
+  price: string;
+  itemIds: string[];
+  amounts: number[];
+  additionalParameters: string;
+}
+
+export interface MultisigCreateOrderRequest {
+  type: "multisig";
+  messageHash: string;
+  chainId: number;
+}
+
+export type LegacyCreateOrderRequest = Omit<EOACreateOrderRequest, "type">;
+
+export type CreateOrderRequest =
+  | EOACreateOrderRequest
+  | MultisigCreateOrderRequest
+  | LegacyCreateOrderRequest;
+
+export interface UpdateOrderNonceRequest {
+  address: string;
+  chainId: number;
+}
+
+export interface ValidateOrderRequest {
+  tokenIds: string[];
+  chainId: number;
+}
 
 // Blueprint-related interfaces
 export interface BlueprintCreateRequest {

--- a/src/types/supabaseData.ts
+++ b/src/types/supabaseData.ts
@@ -728,7 +728,9 @@ export type Database = {
       };
     };
     Enums: {
-      signature_request_purpose_enum: "update_user_data";
+      signature_request_purpose_enum:
+        | "update_user_data"
+        | "create_marketplace_order";
       signature_request_status_enum: "pending" | "executed" | "canceled";
     };
     CompositeTypes: {

--- a/supabase/migrations/20250328123629_update_signature_request_purpose.sql
+++ b/supabase/migrations/20250328123629_update_signature_request_purpose.sql
@@ -1,0 +1,1 @@
+alter type signature_request_purpose_enum add value 'create_marketplace_order';

--- a/test/lib/marketplace/request-parser.test.ts
+++ b/test/lib/marketplace/request-parser.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect } from "vitest";
+import { parseCreateOrderRequest } from "../../../src/lib/marketplace/request-parser.js";
+import { ParseError } from "../../../src/lib/errors/request-parsing.js";
+
+describe("parseCreateOrderRequest", () => {
+  const mockEoaOrder = {
+    type: "eoa",
+    signature:
+      "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
+    chainId: 11155111,
+    quoteType: 0,
+    globalNonce: "1",
+    subsetNonce: 0,
+    orderNonce: "1",
+    strategyId: 0,
+    collectionType: 0,
+    collection: "0xa16DFb32Eb140a6f3F2AC68f41dAd8c7e83C4941",
+    currency: "0x1234567890123456789012345678901234567890",
+    signer: "0x1234567890123456789012345678901234567890",
+    startTime: 1620000000,
+    endTime: 1630000000,
+    price: "1000000000000000000",
+    itemIds: ["1"],
+    amounts: [1],
+    additionalParameters: "0x",
+  };
+
+  const mockMultisigOrder = {
+    type: "multisig",
+    messageHash:
+      "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
+    chainId: 11155111,
+  };
+
+  it("successfully parses an EOA order request", () => {
+    const result = parseCreateOrderRequest(mockEoaOrder);
+    expect(result).toEqual(mockEoaOrder);
+  });
+
+  it("successfully parses a multisig order request", () => {
+    const result = parseCreateOrderRequest(mockMultisigOrder);
+    expect(result).toEqual(mockMultisigOrder);
+  });
+
+  it("handles legacy order format by adding type", () => {
+    const legacyOrder = {
+      signature: mockEoaOrder.signature,
+      chainId: mockEoaOrder.chainId,
+      quoteType: mockEoaOrder.quoteType,
+      globalNonce: mockEoaOrder.globalNonce,
+      subsetNonce: mockEoaOrder.subsetNonce,
+      orderNonce: mockEoaOrder.orderNonce,
+      strategyId: mockEoaOrder.strategyId,
+      collectionType: mockEoaOrder.collectionType,
+      collection: mockEoaOrder.collection,
+      currency: mockEoaOrder.currency,
+      signer: mockEoaOrder.signer,
+      startTime: mockEoaOrder.startTime,
+      endTime: mockEoaOrder.endTime,
+      price: mockEoaOrder.price,
+      itemIds: mockEoaOrder.itemIds,
+      amounts: mockEoaOrder.amounts,
+      additionalParameters: mockEoaOrder.additionalParameters,
+    };
+
+    const result = parseCreateOrderRequest(legacyOrder);
+    expect(result).toEqual({ ...legacyOrder, type: "eoa" });
+  });
+
+  it("throws ParseError for invalid order request", () => {
+    const invalidOrder = {
+      type: "invalid",
+      signature: "0x1234567890abcdef",
+    };
+
+    expect(() => parseCreateOrderRequest(invalidOrder)).toThrow(ParseError);
+  });
+
+  it("throws ParseError for non-object input", () => {
+    expect(() => parseCreateOrderRequest(null)).toThrow(ParseError);
+    expect(() => parseCreateOrderRequest(undefined)).toThrow(ParseError);
+    expect(() => parseCreateOrderRequest("string")).toThrow(ParseError);
+    expect(() => parseCreateOrderRequest(123)).toThrow(ParseError);
+    expect(() => parseCreateOrderRequest(true)).toThrow(ParseError);
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -13,7 +13,7 @@ export default defineConfig({
       thresholds: {
         lines: 24,
         branches: 72,
-        functions: 59,
+        functions: 58,
         statements: 24,
       },
       include: ["src/**/*.ts"],


### PR DESCRIPTION
This PR adds support for creating marketplace listings from your Safe. 

It therefore changes the payload structure for the `POST /marketplace/orders` request to expect a discriminated union of either the EOA request or the multisig request. For backwards compatibility the previous request structure is also supported.

My recommendation would be to ship this PR and the [Hypercerts SDK PR](https://github.com/hypercerts-org/hypercerts-sdk/pull/39) first, update the app to point to the new SDK version and test the review build there.