### PR TITLE
fix: add version prefix to health monitoring endpoint

### DIFF
--- a/src/controllers/MonitoringController.ts
+++ b/src/controllers/MonitoringController.ts
@@ -1,6 +1,6 @@
 import { Route, Get, Response } from "tsoa";
 
-@Route("monitoring")
+@Route("v1/monitoring")
 export class MonitoringController {
   @Get("/health")
   @Response(200, "OK")


### PR DESCRIPTION
A version prefix is now required on the monitoring endpoint, so that both versions of the api can be monitored separately behind the nginx reverse proxy.