### PR TITLE
feat(graphql): add 'burned' field to various types and inputs

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -44,6 +44,7 @@ type AllowlistRecord {
 
 input AllowlistRecordHypercertWhereInput {
   attestations_count: NumberSearchOptions
+  burned: BooleanSearchOptions
   creation_block_number: BigIntSearchOptions
   creation_block_timestamp: BigIntSearchOptions
   creator_address: StringSearchOptions
@@ -134,6 +135,7 @@ input AttestationAttestationSchemaWhereInput {
 
 input AttestationHypercertWhereInput {
   attestations_count: NumberSearchOptions
+  burned: BooleanSearchOptions
   creation_block_number: BigIntSearchOptions
   creation_block_timestamp: BigIntSearchOptions
   creator_address: StringSearchOptions
@@ -331,6 +333,7 @@ input CollectionBlueprintWhereInput {
 
 input CollectionHypercertWhereInput {
   attestations_count: NumberSearchOptions
+  burned: BooleanSearchOptions
   creation_block_number: BigIntSearchOptions
   creation_block_timestamp: BigIntSearchOptions
   creator_address: StringSearchOptions
@@ -398,6 +401,9 @@ scalar EthBigInt
 
 """Fraction of an hypercert"""
 type Fraction {
+  """Whether the fraction has been burned"""
+  burned: Boolean
+
   """The ID of the claims"""
   claims_id: String
 
@@ -461,6 +467,7 @@ input FractionMetadataWhereInput {
 }
 
 input FractionSortOptions {
+  burned: SortOrder = null
   creation_block_number: SortOrder = null
   creation_block_timestamp: SortOrder = null
   fraction_id: SortOrder = null
@@ -474,6 +481,7 @@ input FractionSortOptions {
 }
 
 input FractionWhereInput {
+  burned: BooleanSearchOptions
   creation_block_number: BigIntSearchOptions
   creation_block_timestamp: BigIntSearchOptions
   fraction_id: StringSearchOptions
@@ -667,6 +675,9 @@ type Hypercert {
   """Count of attestations referencing this hypercert"""
   attestations_count: Int
 
+  """Whether the hypercert has been burned"""
+  burned: Boolean
+
   """The contract that the hypercert is associated with"""
   contract: Contract
 
@@ -729,6 +740,9 @@ type HypercertBaseType {
   """Count of attestations referencing this hypercert"""
   attestations_count: Int
 
+  """Whether the hypercert has been burned"""
+  burned: Boolean
+
   """The UUID of the contract as stored in the database"""
   contracts_id: ID
   creation_block_number: EthBigInt
@@ -765,6 +779,7 @@ input HypercertContractWhereInput {
 }
 
 input HypercertFractionWhereInput {
+  burned: BooleanSearchOptions
   creation_block_number: BigIntSearchOptions
   creation_block_timestamp: BigIntSearchOptions
   fraction_id: StringSearchOptions
@@ -796,6 +811,7 @@ input HypercertMetadataWhereInput {
 
 input HypercertSortOptions {
   attestations_count: SortOrder = null
+  burned: SortOrder = null
   creation_block_number: SortOrder = null
   creation_block_timestamp: SortOrder = null
   creator_address: SortOrder = null
@@ -812,6 +828,7 @@ input HypercertSortOptions {
 input HypercertWhereInput {
   attestations: HypercertAttestationWhereInput = {}
   attestations_count: NumberSearchOptions
+  burned: BooleanSearchOptions
   contract: HypercertContractWhereInput = {}
   creation_block_number: BigIntSearchOptions
   creation_block_timestamp: BigIntSearchOptions
@@ -834,6 +851,9 @@ Hypercert with metadata, contract, orders, sales and fraction information
 type HypercertWithMetadata {
   """Count of attestations referencing this hypercert"""
   attestations_count: Int
+
+  """Whether the hypercert has been burned"""
+  burned: Boolean
 
   """The UUID of the contract as stored in the database"""
   contracts_id: ID
@@ -931,6 +951,7 @@ type Metadata {
 
 input MetadataHypercertWhereInput {
   attestations_count: NumberSearchOptions
+  burned: BooleanSearchOptions
   creation_block_number: BigIntSearchOptions
   creation_block_timestamp: BigIntSearchOptions
   creator_address: StringSearchOptions
@@ -1029,6 +1050,7 @@ type Order {
 
 input OrderHypercertWhereInput {
   attestations_count: NumberSearchOptions
+  burned: BooleanSearchOptions
   creation_block_number: BigIntSearchOptions
   creation_block_timestamp: BigIntSearchOptions
   creator_address: StringSearchOptions
@@ -1146,6 +1168,7 @@ type Sale {
 
 input SaleHypercertWhereInput {
   attestations_count: NumberSearchOptions
+  burned: BooleanSearchOptions
   creation_block_number: BigIntSearchOptions
   creation_block_timestamp: BigIntSearchOptions
   creator_address: StringSearchOptions

--- a/src/graphql/schemas/typeDefs/baseTypes/hypercertBaseType.ts
+++ b/src/graphql/schemas/typeDefs/baseTypes/hypercertBaseType.ts
@@ -56,6 +56,12 @@ class HypercertBaseType extends BasicTypeDef {
     description: "Count of sales of fractions that belong to this hypercert",
   })
   sales_count?: number;
+
+  @Field({
+    nullable: true,
+    description: "Whether the hypercert has been burned",
+  })
+  burned?: boolean;
 }
 
 export { HypercertBaseType };

--- a/src/graphql/schemas/typeDefs/fractionTypeDefs.ts
+++ b/src/graphql/schemas/typeDefs/fractionTypeDefs.ts
@@ -87,6 +87,12 @@ export class Fraction extends BasicTypeDef {
     description: "Sales related to this fraction",
   })
   sales?: GetSalesResponse;
+
+  @Field({
+    nullable: true,
+    description: "Whether the fraction has been burned",
+  })
+  burned?: boolean;
 }
 
 @ObjectType()

--- a/src/lib/graphql/whereFieldDefinitions.ts
+++ b/src/lib/graphql/whereFieldDefinitions.ts
@@ -95,6 +95,7 @@ export const WhereFieldDefinitions = {
       hypercert_id: "string",
       fraction_id: "string",
       token_id: "bigint",
+      burned: "boolean",
     },
   },
   Hypercert: {
@@ -111,6 +112,7 @@ export const WhereFieldDefinitions = {
       sales_count: "number",
       attestations_count: "number",
       uri: "string",
+      burned: "boolean",
     },
   },
   Hyperboard: {

--- a/src/services/database/entities/HypercertsEntityService.ts
+++ b/src/services/database/entities/HypercertsEntityService.ts
@@ -28,7 +28,7 @@ export type HypercertSelect = Selectable<CachingDatabase["claims"]>;
 @injectable()
 export class HypercertsService {
   private entityService: EntityService<
-    CachingDatabase["claims"],
+    CachingDatabase["claims_view"],
     GetHypercertsArgs
   >;
 
@@ -38,9 +38,9 @@ export class HypercertsService {
   ) {
     this.entityService = createEntityService<
       CachingDatabase,
-      "claims",
+      "claims_view",
       GetHypercertsArgs
-    >("claims", "HypercertsEntityService", kyselyCaching);
+    >("claims_view", "HypercertsEntityService", kyselyCaching);
   }
 
   /**

--- a/src/services/database/strategies/ClaimsQueryStrategy.ts
+++ b/src/services/database/strategies/ClaimsQueryStrategy.ts
@@ -22,10 +22,10 @@ import { QueryStrategy } from "./QueryStrategy.js";
  */
 export class ClaimsQueryStrategy extends QueryStrategy<
   CachingDatabase,
-  "claims",
+  "claims_view",
   GetHypercertsArgs
 > {
-  protected readonly tableName = "claims" as const;
+  protected readonly tableName = "claims_view" as const;
 
   /**
    * Builds a query to retrieve claim data.
@@ -63,7 +63,7 @@ export class ClaimsQueryStrategy extends QueryStrategy<
             selectFrom("contracts").whereRef(
               "contracts.id",
               "=",
-              "claims.contracts_id",
+              "claims_view.contracts_id",
             ),
           ),
         );
@@ -74,7 +74,7 @@ export class ClaimsQueryStrategy extends QueryStrategy<
             selectFrom("fractions_view").whereRef(
               "fractions_view.claims_id",
               "=",
-              "claims.id",
+              "claims_view.id",
             ),
           ),
         );
@@ -82,7 +82,11 @@ export class ClaimsQueryStrategy extends QueryStrategy<
       .$if(!isWhereEmpty(args.where?.metadata), (qb) => {
         return qb.where(({ exists, selectFrom }) =>
           exists(
-            selectFrom("metadata").whereRef("metadata.uri", "=", "claims.uri"),
+            selectFrom("metadata").whereRef(
+              "metadata.uri",
+              "=",
+              "claims_view.uri",
+            ),
           ),
         );
       })
@@ -92,7 +96,7 @@ export class ClaimsQueryStrategy extends QueryStrategy<
             selectFrom("attestations").whereRef(
               "attestations.claims_id",
               "=",
-              "claims.id",
+              "claims_view.id",
             ),
           ),
         );
@@ -138,7 +142,7 @@ export class ClaimsQueryStrategy extends QueryStrategy<
             selectFrom("contracts").whereRef(
               "contracts.id",
               "=",
-              "claims.contracts_id",
+              "claims_view.contracts_id",
             ),
           ),
         ),
@@ -149,7 +153,7 @@ export class ClaimsQueryStrategy extends QueryStrategy<
             selectFrom("fractions_view").whereRef(
               "fractions_view.claims_id",
               "=",
-              "claims.id",
+              "claims_view.id",
             ),
           ),
         ),
@@ -157,7 +161,11 @@ export class ClaimsQueryStrategy extends QueryStrategy<
       .$if(!isWhereEmpty(args.where?.metadata), (qb) =>
         qb.where(({ exists, selectFrom }) =>
           exists(
-            selectFrom("metadata").whereRef("metadata.uri", "=", "claims.uri"),
+            selectFrom("metadata").whereRef(
+              "metadata.uri",
+              "=",
+              "claims_view.uri",
+            ),
           ),
         ),
       )
@@ -167,7 +175,7 @@ export class ClaimsQueryStrategy extends QueryStrategy<
             selectFrom("attestations").whereRef(
               "attestations.claims_id",
               "=",
-              "claims.id",
+              "claims_view.id",
             ),
           ),
         ),

--- a/src/services/database/strategies/QueryStrategyFactory.ts
+++ b/src/services/database/strategies/QueryStrategyFactory.ts
@@ -67,6 +67,7 @@ export class QueryStrategyFactory {
     blueprints_with_admins: BlueprintsQueryStrategy,
     blueprints: BlueprintsQueryStrategy,
     claims: ClaimsQueryStrategy,
+    claims_view: ClaimsQueryStrategy,
     hypercerts: ClaimsQueryStrategy,
     collections: CollectionsQueryStrategy,
     contracts: ContractsQueryStrategy,

--- a/src/services/graphql/resolvers/hyperboardResolver.ts
+++ b/src/services/graphql/resolvers/hyperboardResolver.ts
@@ -245,6 +245,7 @@ class HyperboardResolver {
               hypercertIds,
             ),
             hypercerts: this.enrichHypercertsWithMetadata(
+              // @ts-expect-error - claim_attestation_count is not in the type
               hypercerts,
               metadataByUri,
             ),

--- a/src/types/supabaseCaching.ts
+++ b/src/types/supabaseCaching.ts
@@ -119,6 +119,13 @@ export type Database = {
             foreignKeyName: "attestations_claims_id_fkey";
             columns: ["claims_id"];
             isOneToOne: false;
+            referencedRelation: "claims_view";
+            referencedColumns: ["id"];
+          },
+          {
+            foreignKeyName: "attestations_claims_id_fkey";
+            columns: ["claims_id"];
+            isOneToOne: false;
             referencedRelation: "hypercert_allowlists_with_claim";
             referencedColumns: ["claim_id"];
           },
@@ -274,6 +281,7 @@ export type Database = {
       };
       fractions: {
         Row: {
+          burned: boolean;
           claims_id: string;
           creation_block_number: number;
           creation_block_timestamp: number;
@@ -287,6 +295,7 @@ export type Database = {
           value: number | null;
         };
         Insert: {
+          burned?: boolean;
           claims_id: string;
           creation_block_number: number;
           creation_block_timestamp: number;
@@ -300,6 +309,7 @@ export type Database = {
           value?: number | null;
         };
         Update: {
+          burned?: boolean;
           claims_id?: string;
           creation_block_number?: number;
           creation_block_timestamp?: number;
@@ -318,6 +328,13 @@ export type Database = {
             columns: ["claims_id"];
             isOneToOne: false;
             referencedRelation: "claims";
+            referencedColumns: ["id"];
+          },
+          {
+            foreignKeyName: "fractions_claims_id_fkey";
+            columns: ["claims_id"];
+            isOneToOne: false;
+            referencedRelation: "claims_view";
             referencedColumns: ["id"];
           },
           {
@@ -387,6 +404,13 @@ export type Database = {
             columns: ["claims_id"];
             isOneToOne: false;
             referencedRelation: "claims";
+            referencedColumns: ["id"];
+          },
+          {
+            foreignKeyName: "hypercert_allow_lists_claims_id_fkey";
+            columns: ["claims_id"];
+            isOneToOne: false;
+            referencedRelation: "claims_view";
             referencedColumns: ["id"];
           },
           {
@@ -559,8 +583,38 @@ export type Database = {
         };
         Relationships: [];
       };
+      claims_view: {
+        Row: {
+          attestations_count: number | null;
+          burned: boolean | null;
+          contracts_id: string | null;
+          creation_block_number: number | null;
+          creation_block_timestamp: number | null;
+          creator_address: string | null;
+          hypercert_id: string | null;
+          id: string | null;
+          last_update_block_number: number | null;
+          last_update_block_timestamp: number | null;
+          owner_address: string | null;
+          sales_count: number | null;
+          token_id: number | null;
+          units: number | null;
+          uri: string | null;
+          value: number | null;
+        };
+        Relationships: [
+          {
+            foreignKeyName: "claims_contracts_id_fkey";
+            columns: ["contracts_id"];
+            isOneToOne: false;
+            referencedRelation: "contracts";
+            referencedColumns: ["id"];
+          },
+        ];
+      };
       fractions_view: {
         Row: {
+          burned: boolean | null;
           claims_id: string | null;
           creation_block_number: number | null;
           creation_block_timestamp: number | null;
@@ -580,6 +634,13 @@ export type Database = {
             columns: ["claims_id"];
             isOneToOne: false;
             referencedRelation: "claims";
+            referencedColumns: ["id"];
+          },
+          {
+            foreignKeyName: "fractions_claims_id_fkey";
+            columns: ["claims_id"];
+            isOneToOne: false;
+            referencedRelation: "claims_view";
             referencedColumns: ["id"];
           },
           {

--- a/test/services/database/strategies/ClaimsQueryStrategy.test.ts
+++ b/test/services/database/strategies/ClaimsQueryStrategy.test.ts
@@ -24,7 +24,7 @@ describe("ClaimsQueryStrategy", () => {
       const { sql } = query.compile();
 
       // Assert
-      expect(sql).toBe('select * from "claims"');
+      expect(sql).toBe('select * from "claims_view"');
     });
 
     it("should build query with contract filter", () => {
@@ -42,7 +42,7 @@ describe("ClaimsQueryStrategy", () => {
       const { sql } = query.compile();
       // Assert
       expect(sql).toContain(
-        'from "contracts" where "contracts"."id" = "claims"."contracts_id"',
+        'from "contracts" where "contracts"."id" = "claims_view"."contracts_id"',
       );
     });
 
@@ -62,7 +62,7 @@ describe("ClaimsQueryStrategy", () => {
 
       // Assert
       expect(sql).toContain(
-        'from "fractions_view" where "fractions_view"."claims_id" = "claims"."id"',
+        'from "fractions_view" where "fractions_view"."claims_id" = "claims_view"."id"',
       );
     });
 
@@ -81,7 +81,7 @@ describe("ClaimsQueryStrategy", () => {
       const { sql } = query.compile();
       // Assert
       expect(sql).toContain(
-        'from "metadata" where "metadata"."uri" = "claims"."uri"',
+        'from "metadata" where "metadata"."uri" = "claims_view"."uri"',
       );
     });
 
@@ -100,7 +100,7 @@ describe("ClaimsQueryStrategy", () => {
       const { sql } = query.compile();
       // Assert
       expect(sql).toContain(
-        'from "attestations" where "attestations"."claims_id" = "claims"."id"',
+        'from "attestations" where "attestations"."claims_id" = "claims_view"."id"',
       );
     });
 
@@ -118,10 +118,10 @@ describe("ClaimsQueryStrategy", () => {
       const { sql } = query.compile();
       // Assert
       expect(sql).toContain(
-        'from "contracts" where "contracts"."id" = "claims"."contracts_id"',
+        'from "contracts" where "contracts"."id" = "claims_view"."contracts_id"',
       );
       expect(sql).toContain(
-        'from "metadata" where "metadata"."uri" = "claims"."uri"',
+        'from "metadata" where "metadata"."uri" = "claims_view"."uri"',
       );
     });
   });
@@ -132,7 +132,7 @@ describe("ClaimsQueryStrategy", () => {
       const query = strategy.buildCountQuery(db);
       const { sql } = query.compile();
       // Assert
-      expect(sql).toBe('select count(*) as "count" from "claims"');
+      expect(sql).toBe('select count(*) as "count" from "claims_view"');
     });
 
     it("should build count query with contract filter", () => {
@@ -150,7 +150,7 @@ describe("ClaimsQueryStrategy", () => {
       const { sql } = query.compile();
       // Assert
       expect(sql).toContain(
-        'from "contracts" where "contracts"."id" = "claims"."contracts_id"',
+        'from "contracts" where "contracts"."id" = "claims_view"."contracts_id"',
       );
       expect(sql).toContain('count(*) as "count"');
     });
@@ -169,10 +169,10 @@ describe("ClaimsQueryStrategy", () => {
       const { sql } = query.compile();
       // Assert
       expect(sql).toContain(
-        'from "contracts" where "contracts"."id" = "claims"."contracts_id"',
+        'from "contracts" where "contracts"."id" = "claims_view"."contracts_id"',
       );
       expect(sql).toContain(
-        'from "metadata" where "metadata"."uri" = "claims"."uri"',
+        'from "metadata" where "metadata"."uri" = "claims_view"."uri"',
       );
       expect(sql).toContain('count(*) as "count"');
     });


### PR DESCRIPTION
- Introduced a 'burned' Boolean field to AllowlistRecordHypercertWhereInput, AttestationHypercertWhereInput, CollectionHypercertWhereInput, Fraction, Hypercert, HypercertBaseType, and several other input types.
- Updated FractionSortOptions and HypercertSortOptions to include sorting by 'burned'.
- Enhanced database entity definitions to accommodate the new 'burned' field in relevant tables and views.